### PR TITLE
Added remaining Map unit tests

### DIFF
--- a/src/google.maps.d.ts
+++ b/src/google.maps.d.ts
@@ -12,4 +12,11 @@ declare namespace google.maps {
     lat(): number;
     lng(): number;
   }
+
+  export class LatLngBounds {
+    constructor(swOrLatLngBounds: google.maps.LatLng | null, ne: google.maps.LatLng | null);
+
+    getNorthEast(): google.maps.LatLng;
+    getSouthWest(): google.maps.LatLng;
+  }
 }

--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -9,6 +9,10 @@ class MigrationLatLng {
 
   constructor(lat: number, lng: number, noWrap?: boolean) {
     // TODO: Need to implement handling of noWrap
+    // TODO: Add support for handling LatLngLiteral
+
+    // These are implemented as property functions instead of prototype functions
+    // to match the google.maps API
     this.lat = function () {
       return lat;
     };
@@ -38,10 +42,40 @@ class MigrationLatLng {
   }
 }
 
+// Migration version of google.maps.LatLngBounds
+// This is only used in adapter standalone mode and in unit tests
+class MigrationLatLngBounds {
+  sw: MigrationLatLng;
+  ne: MigrationLatLng;
+
+  constructor(swOrLatLngBounds, ne) {
+    // TODO: Handle LatLngBoundsLiteral
+
+    this.sw = swOrLatLngBounds;
+    this.ne = ne;
+  }
+
+  getNorthEast() {
+    return this.ne;
+  }
+
+  getSouthWest() {
+    return this.sw;
+  }
+}
+
 // Dynamic function to create a LatLng instance. It will first try google.maps.LatLng
 // and if it's not found, our migration version will be used.
 export const GoogleLatLng = function (lat, lng, noWrap = false) {
   return typeof google !== "undefined"
     ? new google.maps.LatLng(lat, lng, noWrap)
     : new MigrationLatLng(lat, lng, noWrap);
+};
+
+// Dynamic function to create a LatLngBounds instance. It will first try google.maps.LatLngBounds
+// and if it's not found, our migration version will be used.
+export const GoogleLatLngBounds = function (swOrLatLngBounds, ne) {
+  return typeof google !== "undefined"
+    ? new google.maps.LatLngBounds(swOrLatLngBounds, ne)
+    : new MigrationLatLngBounds(swOrLatLngBounds, ne);
 };

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -40,8 +40,7 @@ class MigrationMap {
   getCenter() {
     const center = this._map.getCenter();
 
-    //return new google.maps.LatLng(center.lat, center.lng);
-    return GoogleLatLng(center.lat, center.lng);
+    return GoogleLatLng(center?.lat, center?.lng);
   }
   setCenter(center) {
     this._map.setCenter([center.lng(), center.lat()]);

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MigrationMap } from "../src/maps";
-import { GoogleLatLng } from "../src/googleCommon";
+import { GoogleLatLng, GoogleLatLngBounds } from "../src/googleCommon";
 
 // Mock maplibre because it requires a valid DOM container to create a Map
 // We don't need to verify maplibre itself, we just need to verify that
@@ -14,16 +14,41 @@ import { Map } from "maplibre-gl";
 test("should call setZoom from migration map", () => {
   const testMap = new MigrationMap(null, {});
 
-  expect(testMap.setZoom(3));
+  testMap.setZoom(3);
+
   expect(Map.prototype.setZoom).toHaveBeenCalledTimes(1);
   expect(Map.prototype.setZoom).toHaveBeenCalledWith(3);
 });
 
-test("should call getCenter from migration map", () => {
+test("should call setCenter from migration map", () => {
   const testMap = new MigrationMap(null, {});
   const testCenter = GoogleLatLng(1, 2);
 
-  expect(testMap.setCenter(testCenter));
+  testMap.setCenter(testCenter);
+
   expect(Map.prototype.setCenter).toHaveBeenCalledTimes(1);
   expect(Map.prototype.setCenter).toHaveBeenCalledWith([2, 1]);
+});
+
+test("should call getCenter from migration map", () => {
+  const testMap = new MigrationMap(null, {});
+
+  testMap.getCenter();
+
+  expect(Map.prototype.getCenter).toHaveBeenCalledTimes(1);
+});
+
+test("should call fitBounds from migration map", () => {
+  const testMap = new MigrationMap(null, {});
+  const testSouthWest = GoogleLatLng(1, 2);
+  const testNorthEast = GoogleLatLng(3, 4);
+  const testBounds = GoogleLatLngBounds(testSouthWest, testNorthEast);
+
+  testMap.fitBounds(testBounds);
+
+  expect(Map.prototype.fitBounds).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.fitBounds).toHaveBeenCalledWith([
+    [testNorthEast.lng(), testNorthEast.lat()],
+    [testSouthWest.lng(), testSouthWest.lat()],
+  ]);
 });


### PR DESCRIPTION
## Description
Added unit tests for the remaining `Map` methods that have been implemented: `getCenter` and `fitBounds`

For the `fitBounds` support, this included adding a migration version of `google.maps.LatLngBounds`

Added TODO notes for gaps in the migration implementations that should be filled in later.