### PR TITLE
Ported the route directions from prototype

### DIFF
--- a/src/directions.ts
+++ b/src/directions.ts
@@ -1,8 +1,121 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CalculateRouteCommand, CalculateRouteRequest, LocationClient } from "@aws-sdk/client-location";
+
+import { DirectionsStatus, GoogleLatLng, GoogleLatLngBounds } from "./googleCommon";
 import { MigrationMap } from "./maps";
 import { MigrationMarker } from "./markers";
+import { MigrationPlacesService } from "./places";
+
+class MigrationDirectionsService {
+  // This will be populated by the top level module
+  // that creates our location client
+  _client: LocationClient;
+
+  // This will be populated by the top level module
+  // that is passed our route calculator name
+  _routeCalculatorName: string;
+
+  // This will be populated by the top level module
+  // that already has a MigrationPlacesService that has
+  // been configured with our place index name
+  _placesService: MigrationPlacesService;
+
+  route(options) {
+    return new Promise((resolve, reject) => {
+      // TODO: Rewrite this method using promises (also will need to make a versionof findPlaceFromQuery
+      // returns a promise instead of using a callback) so we can handle the other use-case where
+      // instead of origin.query the source/destination positions are passed as coordinates
+      const originRequest = {
+        query: options.origin.query,
+        fields: ["geometry"],
+      };
+      this._placesService.findPlaceFromQuery(originRequest, (results, status) => {
+        const originLocation = results[0].geometry.location;
+        const departurePosition = [originLocation.lng(), originLocation.lat()];
+
+        // Now get the destination
+        const destinationRequest = {
+          query: options.destination.query,
+          fields: ["geometry"],
+        };
+        this._placesService.findPlaceFromQuery(destinationRequest, (results, status) => {
+          const destinationLocation = results[0].geometry.location;
+          const destinationPosition = [destinationLocation.lng(), destinationLocation.lat()];
+
+          const input: CalculateRouteRequest = {
+            CalculatorName: this._routeCalculatorName, // required
+            DeparturePosition: departurePosition, // required
+            DestinationPosition: destinationPosition, // required
+            TravelMode: "Car", // FIXME: Convert this from the input options
+            IncludeLegGeometry: true,
+          };
+
+          const command = new CalculateRouteCommand(input);
+
+          this._client
+            .send(command)
+            .then((response) => {
+              const bounds = response.Summary.RouteBBox;
+
+              const googleLegs = [];
+              response.Legs.forEach(function (leg) {
+                const steps = [];
+                leg.Steps.forEach(function (step) {
+                  steps.push({
+                    duration: {
+                      text: step.DurationSeconds + " seconds", // TODO: Add conversion logic to make this seconds/minutes/hours
+                      value: step.DurationSeconds,
+                    },
+                    start_location: GoogleLatLng(step.StartPosition[1], step.StartPosition[0]),
+                    end_location: GoogleLatLng(step.EndPosition[1], step.EndPosition[0]),
+                  });
+                });
+
+                googleLegs.push({
+                  geometry: leg.Geometry,
+                  steps: steps,
+                  start_location: originLocation,
+                  end_location: destinationLocation,
+                });
+              });
+
+              const googleRoute = {
+                bounds: GoogleLatLngBounds(
+                  {
+                    lng: bounds[0],
+                    lat: bounds[1],
+                  },
+                  {
+                    lng: bounds[2],
+                    lat: bounds[3],
+                  },
+                ),
+                legs: googleLegs,
+              };
+
+              const googleResponse = {
+                geocoded_waypoints: [], // TODO: Fill these out if the source/destination were passed as queries
+                request: options,
+                routes: [googleRoute],
+                status: DirectionsStatus.OK,
+              };
+
+              resolve(googleResponse);
+            })
+            .catch((error) => {
+              console.error(error);
+
+              reject({
+                status: DirectionsStatus.UNKNOWN_ERROR,
+              });
+            });
+        });
+      });
+    });
+  }
+}
 
 class MigrationDirectionsRenderer {
   _markers: MigrationMarker[];
@@ -93,4 +206,4 @@ class MigrationDirectionsRenderer {
   }
 }
 
-export { MigrationDirectionsRenderer };
+export { MigrationDirectionsService, MigrationDirectionsRenderer };

--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -90,6 +90,17 @@ export const PlacesServiceStatus = {
   NOT_FOUND: "NOT_FOUND",
 };
 
+export const DirectionsStatus = {
+  OK: "OK",
+  UNKNOWN_ERROR: "UNKNOWN_ERROR",
+  OVER_QUERY_LIMIT: "OVER_QUERY_LIMIT",
+  REQUEST_DENIED: "REQUEST_DENIED",
+  INVALID_REQUEST: "INVALID_REQUEST",
+  ZERO_RESULTS: "ZERO_RESULTS",
+  MAX_WAYPOINTS_EXCEEDED: "MAX_WAYPOINTS_EXCEEDED",
+  NOT_FOUND: "NOT_FOUND",
+};
+
 export interface QueryAutocompletePrediction {
   description: string;
   place_id?: string;


### PR DESCRIPTION
## Description

Ported the `route` method for the `DirectionsService` from the prototype.
* The `route` method currently only supports source/destination as query strings instead of additionally supporting coordinates, which will be added in the future
* Added support for `findPlaceFromQuery` which is needed for the `route` method to retrieve a location based on a query string for the place