### PR TITLE
Added map get methods

### DIFF
--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -84,7 +84,7 @@ export const GoogleLatLngBounds = function (swOrLatLngBounds, ne) {
 // longitude and latitude (valid MapLibre input), returns 'null' if 'coord' parameter
 // is not a Google LatLng or LatLngLiteral
 export const LatLngToLngLat = function (coord): [number, number] {
-  if (coord.lng && coord.lat) {
+  if (coord.lng !== undefined && coord.lat !== undefined) {
     if (typeof coord.lng === "number" && typeof coord.lat === "number") {
       return [coord.lng, coord.lat];
     } else if (typeof coord.lng === "function" && typeof coord.lat === "function") {

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -32,18 +32,18 @@ class MigrationMap {
       }
     }
 
-    // MapLibre offers 0-24 zoom, Google can potentially go higher based on location
+    // MapLibre offers 0-24 zoom (handles out of bounds), Google can potentially go higher based on location
     // see more: https://developers.google.com/maps/documentation/javascript/maxzoom
     if (options.zoom) {
-      maplibreOptions.zoom = options.zoom > 24 ? 24 : options.zoom < 0 ? 0 : options.zoom;
+      maplibreOptions.zoom = options.zoom;
     }
 
     if (options.maxZoom) {
-      maplibreOptions.maxZoom = options.maxZoom > 24 ? 24 : options.maxZoom < 0 ? 0 : options.maxZoom;
+      maplibreOptions.maxZoom = options.maxZoom;
     }
 
     if (options.minZoom) {
-      maplibreOptions.minZoom = options.minZoom > 24 ? 24 : options.minZoom < 0 ? 0 : options.minZoom;
+      maplibreOptions.minZoom = options.minZoom;
     }
 
     if (options.heading) {
@@ -81,8 +81,26 @@ class MigrationMap {
 
     return GoogleLatLng(center?.lat, center?.lng);
   }
+
+  getDiv() {
+    return this._map.getContainer();
+  }
+
+  getHeading() {
+    return this._map.getBearing();
+  }
+
+  getTilt() {
+    return this._map.getPitch();
+  }
+
+  getZoom() {
+    return this._map.getZoom();
+  }
+
   setCenter(center) {
-    this._map.setCenter([center.lng(), center.lat()]);
+    const lnglat = LatLngToLngLat(center);
+    this._map.setCenter(lnglat);
   }
 
   fitBounds(bounds) {

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -66,26 +66,6 @@ test("should set migration map options with control position not available in Ma
   expect(Map.prototype.addControl).toHaveBeenCalledWith(expect.any(NavigationControl), "bottom-right");
 });
 
-test("should set migration map options with zoom options not available in MapLibre", () => {
-  const testMap = new MigrationMap(null, {
-    center: { lat: 30.268193, lng: -97.7457518 }, // Austin, TX :)
-    zoom: -2,
-    minZoom: -2,
-    maxZoom: 30,
-  });
-
-  const expectedMaplibreOptions: MapOptions = {
-    container: null,
-    style: undefined,
-    center: [-97.7457518, 30.268193],
-    zoom: 0,
-    minZoom: 0,
-    maxZoom: 24,
-  };
-  expect(Map).toHaveBeenCalledTimes(1);
-  expect(Map).toHaveBeenCalledWith(expectedMaplibreOptions);
-});
-
 test("should call setZoom from migration map", () => {
   const testMap = new MigrationMap(null, {});
 
@@ -95,7 +75,7 @@ test("should call setZoom from migration map", () => {
   expect(Map.prototype.setZoom).toHaveBeenCalledWith(3);
 });
 
-test("should call setCenter from migration map", () => {
+test("should call setCenter from migration map with LatLng", () => {
   const testMap = new MigrationMap(null, {});
   const testCenter = GoogleLatLng(1, 2);
 
@@ -105,12 +85,30 @@ test("should call setCenter from migration map", () => {
   expect(Map.prototype.setCenter).toHaveBeenCalledWith([2, 1]);
 });
 
-test("should call getCenter from migration map", () => {
+test("should call setCenter from migration map with LatLngLiteral", () => {
+  const testMap = new MigrationMap(null, {});
+  const testCenter = { lat: 3, lng: 4 };
+
+  testMap.setCenter(testCenter);
+
+  expect(Map.prototype.setCenter).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.setCenter).toHaveBeenCalledWith([4, 3]);
+});
+
+test("should call get methods from migration map", () => {
   const testMap = new MigrationMap(null, {});
 
   testMap.getCenter();
+  testMap.getDiv();
+  testMap.getHeading();
+  testMap.getTilt();
+  testMap.getZoom();
 
   expect(Map.prototype.getCenter).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.getContainer).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.getBearing).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.getPitch).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.getZoom).toHaveBeenCalledTimes(1);
 });
 
 test("should call fitBounds from migration map", () => {


### PR DESCRIPTION
- Added `getDiv`, `getHeading`, `getTilt`, `getZoom` methods for MigrationMap class. 
- Removed bounds logic in zoom-related `MapOptions` because after further testing, realized MapLibre handles this for us. 
- Fixed edge case in `LatLngToLngLat` helper method where it could not translate [0,0] coordinate
- `setCenter` can now handle `LatLngLiteral` inputs with use of `LatLngToLngLat` helper function
