### PR TITLE
Dynamically load the maplibre css file

### DIFF
--- a/examples/autoComplete/index.html
+++ b/examples/autoComplete/index.html
@@ -11,9 +11,6 @@
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
 
-    <!-- TODO: Move the maplibre stylesheet to be loaded dynamically by the migration adapter -->
-    <link href="https://unpkg.com/maplibre-gl@3.x/dist/maplibre-gl.css" rel="stylesheet" />
-
     <!-- Migration script import -->
     <script src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&placeIndex=<YOUR_PLACE_INDEX>&apiKey=<YOUR_AMAZON_API_KEY>"></script>
   </head>

--- a/examples/basicMap/index.html
+++ b/examples/basicMap/index.html
@@ -6,9 +6,6 @@
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
 
-    <!-- TODO: Move the maplibre stylesheet to be loaded dynamically by the migration adapter -->
-    <link href="https://unpkg.com/maplibre-gl@3.x/dist/maplibre-gl.css" rel="stylesheet" />
-
     <!-- Migration script import -->
     <script src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&placeIndex=<YOUR_PLACE_INDEX>&apiKey=<YOUR_AMAZON_API_KEY>"></script>
   </head>

--- a/examples/directions/index.html
+++ b/examples/directions/index.html
@@ -3,9 +3,6 @@
     <title>Directions Example - Migration Adapter</title>
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
 
-    <!-- TODO: Move the maplibre stylesheet to be loaded dynamically by the migration adapter -->
-    <link href="https://unpkg.com/maplibre-gl@3.x/dist/maplibre-gl.css" rel="stylesheet" />
-
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,13 @@ import { MigrationMap } from "./maps";
 import { MigrationMarker } from "./markers";
 import { MigrationAutocompleteService, MigrationPlacesService } from "./places";
 
+// Dynamically load the MapLibre stylesheet so that our migration adapter is the only thing our users need to import
+// Without this, many MapLibre rendering features won't work (e.g. markers and info windows won't be visible)
+const style = document.createElement("link");
+style.setAttribute("rel", "stylesheet");
+style.setAttribute("href", "https://unpkg.com/maplibre-gl@3.x/dist/maplibre-gl.css");
+document.head.appendChild(style);
+
 // This migration helper will replace classes/methods in the google.maps namespace
 // to target our AWS Location Service migration server shim endpoint instead of
 // the Google Maps API endpoint


### PR DESCRIPTION
## Description
Added support to our adapter to dynamically load the maplibre css file upon import, instead of having to explicitly include it. Also updated our examples to remove the explicit loading of the maplibre css file.

## Testing
Ran the examples locally and verified that the maplibre css file is loaded, and markers still work as expected.