### PR TITLE
Added basic map event functionality

### DIFF
--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -165,6 +165,11 @@ GoogleToMaplibreControlPosition[MigrationControlPosition.RIGHT_BOTTOM] = "bottom
 GoogleToMaplibreControlPosition[MigrationControlPosition.BOTTOM_LEFT] = "bottom-left";
 GoogleToMaplibreControlPosition[MigrationControlPosition.BOTTOM_RIGHT] = "bottom-right";
 
+export const MigrationMapEvent = {
+  click: "click",
+  dblclick: "dblclick",
+};
+
 export interface QueryAutocompletePrediction {
   description: string;
   place_id?: string;

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CameraOptions, IControl, Map, MapOptions, NavigationControl } from "maplibre-gl";
-import { GoogleLatLng, GoogleLatLngBounds, GoogleToMaplibreControlPosition, LatLngToLngLat } from "./googleCommon";
+import {
+  GoogleLatLng,
+  GoogleLatLngBounds,
+  GoogleToMaplibreControlPosition,
+  LatLngToLngLat,
+  MigrationMapEvent,
+} from "./googleCommon";
 
 /*
   This migration map class is a thin wrapper replacement for google.maps.Map, which
@@ -62,6 +68,20 @@ class MigrationMap {
     if (options.zoomControl === undefined || options.zoomControl === true) {
       this.#addNavigationControl(options.zoomControlOptions);
     }
+  }
+
+  addListener(eventName, handler) {
+    if (eventName === MigrationMapEvent.click || eventName === MigrationMapEvent.dblclick) {
+      this.#map.on(eventName, (mapLibreMapMouseEvent) => {
+        const googleMapMouseEvent = {
+          domEvent: mapLibreMapMouseEvent.originalEvent,
+          latLng: GoogleLatLng(mapLibreMapMouseEvent.lngLat.lat, mapLibreMapMouseEvent.lngLat.lng),
+        };
+        handler(googleMapMouseEvent);
+      });
+    }
+
+    // TODO: add more else if statements with rest of the map events
   }
 
   getBounds() {

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -347,3 +347,78 @@ test("should call fitBounds from migration map with invalid padding", () => {
     [testSouthWest.lng(), testSouthWest.lat()],
   ]);
 });
+
+test("should call addListener from migration map", () => {
+  const testMap = new MigrationMap(null, {});
+
+  testMap.addListener("click", () => {});
+  testMap.addListener("dblclick", () => {});
+
+  expect(Map.prototype.on).toHaveBeenCalledTimes(2);
+  expect(Map.prototype.on).toHaveBeenCalledWith("click", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("dblclick", expect.any(Function));
+});
+
+test("should call handler with translated MapMouseEvent after click", () => {
+  // mock map so that we can mock on so that we can mock click
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMap.addListener("click", handlerSpy);
+
+  // mock click
+  const mockMapLibreMapMouseEvent = {
+    originalEvent: "click",
+    lngLat: { lat: 1, lng: 2 },
+  };
+  mockMap.on.mock.calls[0][1](mockMapLibreMapMouseEvent);
+
+  // expected translated MapMouseEvent (Google's version)
+  const expectedGoogleMapMouseEvent = {
+    domEvent: "click",
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMapMouseEvent);
+});
+
+test("should call handler with translated MapMouseEvent after dblclick", () => {
+  // mock map so that we can mock on so that we can mock click
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMap.addListener("dblclick", handlerSpy);
+
+  // mock click
+  const mockMapLibreMapMouseEvent = {
+    originalEvent: "dblclick",
+    lngLat: { lat: 3, lng: 4 },
+  };
+  mockMap.on.mock.calls[0][1](mockMapLibreMapMouseEvent);
+
+  // expected translated MapMouseEvent (Google's version)
+  const expectedGoogleMapMouseEvent = {
+    domEvent: "dblclick",
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMapMouseEvent);
+});


### PR DESCRIPTION
- Added first example of handling an event; implemented map `click` and `dblclick`
- Used Google's [events system](https://developers.google.com/maps/documentation/javascript/reference/event) and MapLibre's [on method](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#on)