### PR TITLE
Added more map events

### DIFF
--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -165,10 +165,57 @@ GoogleToMaplibreControlPosition[MigrationControlPosition.RIGHT_BOTTOM] = "bottom
 GoogleToMaplibreControlPosition[MigrationControlPosition.BOTTOM_LEFT] = "bottom-left";
 GoogleToMaplibreControlPosition[MigrationControlPosition.BOTTOM_RIGHT] = "bottom-right";
 
+// Migration version of Google's Map Events
 export const MigrationMapEvent = {
   click: "click",
   dblclick: "dblclick",
+  contextmenu: "contextmenu",
+  mousemove: "mousemove",
+  mouseout: "mouseout",
+  mouseover: "mouseover",
+  tilesloaded: "tilesloaded",
+  tilt_changed: "tilt_changed",
+  zoom_changed: "zoom_changed",
+  drag: "drag",
+  dragend: "dragend",
+  dragstart: "dragstart",
 };
+
+// Constant responsible for translating Google Event names to corresponding MapLibre Event names,
+// these Event names are passed into MapLibre's 'on' method
+export const GoogleToMaplibreMapEvent = {};
+GoogleToMaplibreMapEvent[MigrationMapEvent.click] = "click";
+GoogleToMaplibreMapEvent[MigrationMapEvent.dblclick] = "dblclick";
+GoogleToMaplibreMapEvent[MigrationMapEvent.contextmenu] = "contextmenu";
+GoogleToMaplibreMapEvent[MigrationMapEvent.mousemove] = "mousemove";
+GoogleToMaplibreMapEvent[MigrationMapEvent.mouseout] = "mouseout";
+GoogleToMaplibreMapEvent[MigrationMapEvent.mouseover] = "mouseover";
+GoogleToMaplibreMapEvent[MigrationMapEvent.tilesloaded] = "load";
+GoogleToMaplibreMapEvent[MigrationMapEvent.tilt_changed] = "pitch";
+GoogleToMaplibreMapEvent[MigrationMapEvent.zoom_changed] = "zoom";
+GoogleToMaplibreMapEvent[MigrationMapEvent.drag] = "drag";
+GoogleToMaplibreMapEvent[MigrationMapEvent.dragend] = "dragend";
+GoogleToMaplibreMapEvent[MigrationMapEvent.dragstart] = "dragstart";
+
+// List of Google Events that include the MapMouseEvent parameter
+export const GoogleMapMouseEvent = [
+  MigrationMapEvent.click,
+  MigrationMapEvent.dblclick,
+  MigrationMapEvent.contextmenu,
+  MigrationMapEvent.mousemove,
+  MigrationMapEvent.mouseout,
+  MigrationMapEvent.mouseover,
+];
+
+// List of Google Events that do not have any parameters
+export const GoogleMapEvent = [
+  MigrationMapEvent.tilesloaded,
+  MigrationMapEvent.tilt_changed,
+  MigrationMapEvent.zoom_changed,
+  MigrationMapEvent.drag,
+  MigrationMapEvent.dragend,
+  MigrationMapEvent.dragstart,
+];
 
 export interface QueryAutocompletePrediction {
   description: string;

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -5,9 +5,11 @@ import { CameraOptions, IControl, Map, MapOptions, NavigationControl } from "map
 import {
   GoogleLatLng,
   GoogleLatLngBounds,
+  GoogleMapEvent,
+  GoogleMapMouseEvent,
   GoogleToMaplibreControlPosition,
+  GoogleToMaplibreMapEvent,
   LatLngToLngLat,
-  MigrationMapEvent,
 } from "./googleCommon";
 
 /*
@@ -71,17 +73,19 @@ class MigrationMap {
   }
 
   addListener(eventName, handler) {
-    if (eventName === MigrationMapEvent.click || eventName === MigrationMapEvent.dblclick) {
-      this.#map.on(eventName, (mapLibreMapMouseEvent) => {
+    if (GoogleMapMouseEvent.includes(eventName)) {
+      this.#map.on(GoogleToMaplibreMapEvent[eventName], (mapLibreMapMouseEvent) => {
         const googleMapMouseEvent = {
           domEvent: mapLibreMapMouseEvent.originalEvent,
           latLng: GoogleLatLng(mapLibreMapMouseEvent.lngLat.lat, mapLibreMapMouseEvent.lngLat.lng),
         };
         handler(googleMapMouseEvent);
       });
+    } else if (GoogleMapEvent.includes(eventName)) {
+      this.#map.on(GoogleToMaplibreMapEvent[eventName], () => {
+        handler();
+      });
     }
-
-    // TODO: add more else if statements with rest of the map events
   }
 
   getBounds() {

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -353,10 +353,30 @@ test("should call addListener from migration map", () => {
 
   testMap.addListener("click", () => {});
   testMap.addListener("dblclick", () => {});
+  testMap.addListener("contextmenu", () => {});
+  testMap.addListener("mousemove", () => {});
+  testMap.addListener("mouseout", () => {});
+  testMap.addListener("mouseover", () => {});
+  testMap.addListener("tilesloaded", () => {});
+  testMap.addListener("tilt_changed", () => {});
+  testMap.addListener("zoom_changed", () => {});
+  testMap.addListener("drag", () => {});
+  testMap.addListener("dragend", () => {});
+  testMap.addListener("dragstart", () => {});
 
-  expect(Map.prototype.on).toHaveBeenCalledTimes(2);
+  expect(Map.prototype.on).toHaveBeenCalledTimes(12);
   expect(Map.prototype.on).toHaveBeenCalledWith("click", expect.any(Function));
   expect(Map.prototype.on).toHaveBeenCalledWith("dblclick", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("contextmenu", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("mousemove", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("mouseout", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("mouseover", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("load", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("pitch", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("zoom", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("drag", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("dragend", expect.any(Function));
+  expect(Map.prototype.on).toHaveBeenCalledWith("dragstart", expect.any(Function));
 });
 
 test("should call handler with translated MapMouseEvent after click", () => {
@@ -403,7 +423,7 @@ test("should call handler with translated MapMouseEvent after dblclick", () => {
   const handlerSpy = jest.fn();
   migrationMap.addListener("dblclick", handlerSpy);
 
-  // mock click
+  // mock double click
   const mockMapLibreMapMouseEvent = {
     originalEvent: "dblclick",
     lngLat: { lat: 3, lng: 4 },
@@ -413,6 +433,134 @@ test("should call handler with translated MapMouseEvent after dblclick", () => {
   // expected translated MapMouseEvent (Google's version)
   const expectedGoogleMapMouseEvent = {
     domEvent: "dblclick",
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMapMouseEvent);
+});
+
+test("should call handler with translated MapMouseEvent after contextmenu", () => {
+  // mock map so that we can mock on so that we can mock click
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMap.addListener("contextmenu", handlerSpy);
+
+  // mock context menu
+  const mockMapLibreMapMouseEvent = {
+    originalEvent: "contextmenu",
+    lngLat: { lat: 3, lng: 4 },
+  };
+  mockMap.on.mock.calls[0][1](mockMapLibreMapMouseEvent);
+
+  // expected translated MapMouseEvent (Google's version)
+  const expectedGoogleMapMouseEvent = {
+    domEvent: "contextmenu",
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMapMouseEvent);
+});
+
+test("should call handler with translated MapMouseEvent after mousemove", () => {
+  // mock map so that we can mock on so that we can mock click
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMap.addListener("mousemove", handlerSpy);
+
+  // mock move mouse
+  const mockMapLibreMapMouseEvent = {
+    originalEvent: "mousemove",
+    lngLat: { lat: 3, lng: 4 },
+  };
+  mockMap.on.mock.calls[0][1](mockMapLibreMapMouseEvent);
+
+  // expected translated MapMouseEvent (Google's version)
+  const expectedGoogleMapMouseEvent = {
+    domEvent: "mousemove",
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMapMouseEvent);
+});
+
+test("should call handler with translated MapMouseEvent after mouseout", () => {
+  // mock map so that we can mock on so that we can mock click
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMap.addListener("mouseout", handlerSpy);
+
+  // mock mouseout
+  const mockMapLibreMapMouseEvent = {
+    originalEvent: "mouseout",
+    lngLat: { lat: 3, lng: 4 },
+  };
+  mockMap.on.mock.calls[0][1](mockMapLibreMapMouseEvent);
+
+  // expected translated MapMouseEvent (Google's version)
+  const expectedGoogleMapMouseEvent = {
+    domEvent: "mouseout",
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMapMouseEvent);
+});
+
+test("should call handler with translated MapMouseEvent after mouseover", () => {
+  // mock map so that we can mock on so that we can mock click
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMap.addListener("mouseover", handlerSpy);
+
+  // mock mouseover
+  const mockMapLibreMapMouseEvent = {
+    originalEvent: "mouseover",
+    lngLat: { lat: 3, lng: 4 },
+  };
+  mockMap.on.mock.calls[0][1](mockMapLibreMapMouseEvent);
+
+  // expected translated MapMouseEvent (Google's version)
+  const expectedGoogleMapMouseEvent = {
+    domEvent: "mouseover",
     latLng: {
       lat: expect.any(Function),
       lng: expect.any(Function),


### PR DESCRIPTION
- Added `contextmenu`, `mousemove`, `mouseout`, `mouseover`, `tilesloaded`, `tilt_changed`, `zoom_changed`, `drag`, `dragend`, `dragstart` map events
- Added constants for translating Google map event names to MapLibre map event names as well as constants for separating Google map events that include the MapMouseEvent parameter with events that do not have any parameters