### PR TITLE
Changed the hosted examples port

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ npm run hostExamples
 
 ### Basic map
 
-- http://localhost:3000/examples/basicMap/index.html
-- http://localhost:3000/examples/basicMap/google.html
+- http://localhost:8080/examples/basicMap/index.html
+- http://localhost:8080/examples/basicMap/google.html
 
 ### Autocomplete
 
-- http://localhost:3000/examples/autoComplete/index.html
-- http://localhost:3000/examples/autoComplete/google.html
+- http://localhost:8080/examples/autoComplete/index.html
+- http://localhost:8080/examples/autoComplete/google.html
 
 ### Directions
 
-- http://localhost:3000/examples/directions/index.html
-- http://localhost:3000/examples/directions/google.html
+- http://localhost:8080/examples/directions/index.html
+- http://localhost:8080/examples/directions/google.html
 
 ## Security
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,6 @@ export default defineConfig({
     global: {},
   },
   server: {
-    port: 3000,
+    port: 8080,
   },
 });


### PR DESCRIPTION
## Description
Changed the default port for hosting the examples from `3000` to `8080`. Also updated the README with the new examples links after changing the port.