### PR TITLE
Added examples landing page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <title>Migration Adapter Examples</title>
+
+    <link rel="stylesheet" type="text/css" href="./common/style.css" />
+  </head>
+  <body>
+    <h1>Amazon Location Migration Adapter Examples</h1>
+    <p>
+      Here are several example use-cases for using the adapter, along with the same example using only the Google SDK.
+    </p>
+
+    <div>
+      <span class="example-links"><a href="./basicMap/index.html" target="_blank">Basic map</a></span>
+      <span><a href="./basicMap/google.html" target="_blank">(Google)</a></span>
+    </div>
+
+    <div>
+      <span class="example-links"><a href="./autoComplete/index.html" target="_blank">Autocomplete</a></span>
+      <span><a href="./autoComplete/google.html" target="_blank">(Google)</a></span>
+    </div>
+
+    <div>
+      <span class="example-links"><a href="./directions/index.html" target="_blank">Directions</a></span>
+      <span><a href="./directions/google.html" target="_blank">(Google)</a></span>
+    </div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build-ts:esm": "tsc --esModuleInterop --module esnext --outDir dist/esm",
     "prepare": "husky install",
     "prepublishOnly": "npm-run-all clean lint prettier:check test build",
-    "hostExamples": "vite --open"
+    "hostExamples": "vite"
   },
   "jest": {
     "testMatch": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
     global: {},
   },
   server: {
+    open: "/examples/index.html",
     port: 8080,
   },
 });


### PR DESCRIPTION
## Description

Added landing page for the examples that just has links for opening each example (adapter + google version). Modified the `vite` config to open to the landing page by default when running `npm run hostExamples`.

## Testing

Ran `npm run hostExamples` and verified that the landing page is opened in the browser. Clicked on all the example links and verified they open the correct pages.