### PR TITLE
Added CODEOWNERS for our repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws-geospatial/amazon-location


### PR DESCRIPTION
## Description

Added `CODEOWNERS` file so that our `@aws-geospatial/amazon-location` group will be automatically added as reviewers for new PRs.