### PR TITLE
Added marker methods

### DIFF
--- a/test/markers.test.ts
+++ b/test/markers.test.ts
@@ -104,3 +104,83 @@ test("should set marker with icon object", () => {
   expect(Marker).toHaveBeenCalledTimes(1);
   expect(Marker).toHaveBeenCalledWith(expectedMaplibreOptions);
 });
+
+test("should call get methods from marker", () => {
+  const testMarker = new MigrationMarker({});
+
+  testMarker.getDraggable();
+  testMarker.getPosition();
+
+  expect(Marker.prototype.isDraggable).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.getLngLat).toHaveBeenCalledTimes(1);
+});
+
+test("should call getIcon from marker", () => {
+  const mockMarker = {
+    getElement: jest.fn().mockReturnValue({
+      src: null,
+    }),
+  };
+  const testMarker = new MigrationMarker({});
+  testMarker._setMarker(mockMarker);
+
+  testMarker.getIcon();
+
+  expect(mockMarker.getElement).toHaveBeenCalledTimes(1);
+});
+
+test("should call set methods from marker", () => {
+  const testMap = new MigrationMap(null, {});
+  const testMarker = new MigrationMarker({});
+
+  testMarker.setDraggable(true);
+  testMarker.setPosition({ lat: testLat, lng: testLng });
+  testMarker.setOpacity(0.5);
+  testMarker.setMap(testMap);
+
+  expect(Marker.prototype.setDraggable).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.setDraggable).toHaveBeenCalledWith(true);
+  expect(Marker.prototype.setLngLat).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.setLngLat).toHaveBeenCalledWith([testLng, testLat]);
+  expect(Marker.prototype.setOpacity).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.setOpacity).toHaveBeenCalledWith(0.5);
+  expect(Marker.prototype.addTo).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.addTo).toHaveBeenCalledWith(testMap._getMap());
+});
+
+test("should call setOptions from marker", () => {
+  const testMap = new MigrationMap(null, {});
+  const testMarker = new MigrationMarker({});
+
+  testMarker.setOptions({
+    draggable: false,
+    position: { lat: testLat, lng: testLng },
+    opacity: 0,
+    map: testMap,
+  });
+
+  expect(Marker.prototype.setDraggable).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.setDraggable).toHaveBeenCalledWith(false);
+  expect(Marker.prototype.setLngLat).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.setLngLat).toHaveBeenCalledWith([testLng, testLat]);
+  expect(Marker.prototype.setOpacity).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.setOpacity).toHaveBeenCalledWith(0);
+  expect(Marker.prototype.addTo).toHaveBeenCalledTimes(1);
+  expect(Marker.prototype.addTo).toHaveBeenCalledWith(testMap._getMap());
+});
+
+test("should call setMap with null and undefined from marker", () => {
+  const testMarker = new MigrationMarker({});
+
+  testMarker.setMap(null);
+  testMarker.setMap(undefined);
+
+  expect(Marker.prototype.remove).toHaveBeenCalledTimes(2);
+});
+test("should call remove from marker", () => {
+  const testMarker = new MigrationMarker({});
+
+  testMarker.remove();
+
+  expect(Marker.prototype.remove).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
- Added `setOptions`, `getDraggable`, `getIcon`, `getPosition`
- Added `_setMarker` for internal use (unit testing)
- Fixed some edge cases where `null`, `undefined`, `0` were valid values, but if-statement logic did not account for these values