### PR TITLE
Extended getDetails support for additional fields

### DIFF
--- a/test/places.test.ts
+++ b/test/places.test.ts
@@ -12,6 +12,8 @@ const testPlaceLabel = "Austin, TX, USA";
 const testLat = 30.268193;
 const testLng = -97.7457518;
 
+const testPlaceWithAddressLabel = "1337 Cool Place Road, Austin, TX, USA";
+
 const clientErrorQuery = "THIS_WILL_CAUSE_A_CLIENT_ERROR";
 
 const mockedClientSend = jest.fn((command) => {
@@ -35,6 +37,26 @@ const mockedClientSend = jest.fn((command) => {
           ],
         });
       }
+    } else if (command instanceof GetPlaceCommand) {
+      if (command.input.PlaceId === undefined) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        resolve({
+          Place: {
+            Label: testPlaceWithAddressLabel,
+            AddressNumber: "1337",
+            Street: "Cool Place Road",
+            Geometry: {
+              Point: [testLng, testLat],
+            },
+            TimeZone: {
+              Offset: -18000,
+            },
+            Municipality: "Austin",
+          },
+        });
+      }
     } else {
       reject();
     }
@@ -49,7 +71,7 @@ jest.mock("@aws-sdk/client-location", () => ({
     };
   }),
 }));
-import { LocationClient, SearchPlaceIndexForTextCommand } from "@aws-sdk/client-location";
+import { GetPlaceCommand, LocationClient, SearchPlaceIndexForTextCommand } from "@aws-sdk/client-location";
 
 const placesService = new MigrationPlacesService();
 placesService._client = new LocationClient();
@@ -69,6 +91,7 @@ test("findPlaceFromQuery should only return the requested fields", (done) => {
     const firstResult = results[0];
 
     expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
 
     const returnedLatLng = firstResult.geometry.location;
     expect(returnedLatLng.lat()).toStrictEqual(testLat);
@@ -96,6 +119,7 @@ test("findPlaceFromQuery should return all fields when ALL are requested", (done
     const firstResult = results[0];
 
     expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
 
     const returnedLatLng = firstResult.geometry.location;
     expect(returnedLatLng.lat()).toStrictEqual(testLat);
@@ -128,6 +152,7 @@ test("findPlaceFromQuery should translate location bias", (done) => {
     const firstResult = results[0];
 
     expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
     const clientInput = mockedClientSend.mock.calls[0][0].input;
     expect(clientInput.BiasPosition[0]).toStrictEqual(biasLng);
     expect(clientInput.BiasPosition[1]).toStrictEqual(biasLat);
@@ -148,6 +173,74 @@ test("findPlaceFromQuery should handle client error", (done) => {
 
   placesService.findPlaceFromQuery(request, (results, status) => {
     expect(results).toHaveLength(0);
+    expect(status).toStrictEqual(PlacesServiceStatus.UNKNOWN_ERROR);
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("getDetails should return all fields by default", (done) => {
+  const request = {
+    placeId: "KEEP_AUSTIN_WEIRD",
+  };
+
+  placesService.getDetails(request, (result, status) => {
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+
+    const returnedLatLng = result.geometry.location;
+    expect(returnedLatLng.lat()).toStrictEqual(testLat);
+    expect(returnedLatLng.lng()).toStrictEqual(testLng);
+    expect(result.name).toStrictEqual("1337 Cool Place Road");
+    expect(result.formatted_address).toStrictEqual(testPlaceWithAddressLabel);
+    expect(result.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    expect(result.reference).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    expect(result.utc_offset).toStrictEqual(-300);
+    expect(result.utc_offset_minutes).toStrictEqual(-300);
+    expect(result.vicinity).toStrictEqual("1337 Cool Place Road, Austin");
+    expect(status).toStrictEqual(PlacesServiceStatus.OK);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("getDetails should only return the requested fields", (done) => {
+  const request = {
+    placeId: "KEEP_AUSTIN_WEIRD",
+    fields: ["name", "vicinity", "place_id"],
+  };
+
+  placesService.getDetails(request, (result, status) => {
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+
+    expect(result.name).toStrictEqual("1337 Cool Place Road");
+    expect(result.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    expect(result.vicinity).toStrictEqual("1337 Cool Place Road, Austin");
+    expect(status).toStrictEqual(PlacesServiceStatus.OK);
+
+    expect(result.geometry).toBeUndefined();
+    expect(result.formatted_address).toBeUndefined();
+    expect(result.reference).toBeUndefined();
+    expect(result.utc_offset).toBeUndefined();
+    expect(result.utc_offset_minutes).toBeUndefined();
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("getDetails should handle client error", (done) => {
+  const request = {
+    placeId: undefined,
+  };
+
+  placesService.getDetails(request, (result, status) => {
+    expect(result).toBeNull();
     expect(status).toStrictEqual(PlacesServiceStatus.UNKNOWN_ERROR);
 
     expect(console.error).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Description
Extended `getDetails` API support for additional fields: time zone, and vicinity.
* Updated `getDetails` to use same helper method as `findPlaceFromQuery` for converting an Amazon Location `Place` object to a Google `Place` object.
* `getDetails` by default will return all supported fields, but can also be passed a `fields` parameter to restrict which fields are returned
* Added unit tests to extend `places` coverage to all `getDetails` logic
* Updated `getDetails` to return `null` for the result if there is an error, to match Google's API

## Testing
Built/ran unit tests, and verified all `getDetails` logic is covered by the unit tests. Also ran `autoComplete` example, which uses `getDetails` API and verified it still works as expected.