### PR TITLE
Added marker events

### DIFF
--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -165,8 +165,8 @@ GoogleToMaplibreControlPosition[MigrationControlPosition.RIGHT_BOTTOM] = "bottom
 GoogleToMaplibreControlPosition[MigrationControlPosition.BOTTOM_LEFT] = "bottom-left";
 GoogleToMaplibreControlPosition[MigrationControlPosition.BOTTOM_RIGHT] = "bottom-right";
 
-// Migration version of Google's Map Events
-export const MigrationMapEvent = {
+// Migration version of Google's Events
+export const MigrationEvent = {
   click: "click",
   dblclick: "dblclick",
   contextmenu: "contextmenu",
@@ -183,39 +183,46 @@ export const MigrationMapEvent = {
 
 // Constant responsible for translating Google Event names to corresponding MapLibre Event names,
 // these Event names are passed into MapLibre's 'on' method
-export const GoogleToMaplibreMapEvent = {};
-GoogleToMaplibreMapEvent[MigrationMapEvent.click] = "click";
-GoogleToMaplibreMapEvent[MigrationMapEvent.dblclick] = "dblclick";
-GoogleToMaplibreMapEvent[MigrationMapEvent.contextmenu] = "contextmenu";
-GoogleToMaplibreMapEvent[MigrationMapEvent.mousemove] = "mousemove";
-GoogleToMaplibreMapEvent[MigrationMapEvent.mouseout] = "mouseout";
-GoogleToMaplibreMapEvent[MigrationMapEvent.mouseover] = "mouseover";
-GoogleToMaplibreMapEvent[MigrationMapEvent.tilesloaded] = "load";
-GoogleToMaplibreMapEvent[MigrationMapEvent.tilt_changed] = "pitch";
-GoogleToMaplibreMapEvent[MigrationMapEvent.zoom_changed] = "zoom";
-GoogleToMaplibreMapEvent[MigrationMapEvent.drag] = "drag";
-GoogleToMaplibreMapEvent[MigrationMapEvent.dragend] = "dragend";
-GoogleToMaplibreMapEvent[MigrationMapEvent.dragstart] = "dragstart";
+export const GoogleToMaplibreEvent = {};
+GoogleToMaplibreEvent[MigrationEvent.click] = "click";
+GoogleToMaplibreEvent[MigrationEvent.dblclick] = "dblclick";
+GoogleToMaplibreEvent[MigrationEvent.contextmenu] = "contextmenu";
+GoogleToMaplibreEvent[MigrationEvent.mousemove] = "mousemove";
+GoogleToMaplibreEvent[MigrationEvent.mouseout] = "mouseout";
+GoogleToMaplibreEvent[MigrationEvent.mouseover] = "mouseover";
+GoogleToMaplibreEvent[MigrationEvent.tilesloaded] = "load";
+GoogleToMaplibreEvent[MigrationEvent.tilt_changed] = "pitch";
+GoogleToMaplibreEvent[MigrationEvent.zoom_changed] = "zoom";
+GoogleToMaplibreEvent[MigrationEvent.drag] = "drag";
+GoogleToMaplibreEvent[MigrationEvent.dragend] = "dragend";
+GoogleToMaplibreEvent[MigrationEvent.dragstart] = "dragstart";
 
-// List of Google Events that include the MapMouseEvent parameter
+// List of Google Map Events that include the MapMouseEvent parameter
 export const GoogleMapMouseEvent = [
-  MigrationMapEvent.click,
-  MigrationMapEvent.dblclick,
-  MigrationMapEvent.contextmenu,
-  MigrationMapEvent.mousemove,
-  MigrationMapEvent.mouseout,
-  MigrationMapEvent.mouseover,
+  MigrationEvent.click,
+  MigrationEvent.dblclick,
+  MigrationEvent.contextmenu,
+  MigrationEvent.mousemove,
+  MigrationEvent.mouseout,
+  MigrationEvent.mouseover,
 ];
 
-// List of Google Events that do not have any parameters
+// List of Google Map Events that do not have any parameters
 export const GoogleMapEvent = [
-  MigrationMapEvent.tilesloaded,
-  MigrationMapEvent.tilt_changed,
-  MigrationMapEvent.zoom_changed,
-  MigrationMapEvent.drag,
-  MigrationMapEvent.dragend,
-  MigrationMapEvent.dragstart,
+  MigrationEvent.tilesloaded,
+  MigrationEvent.tilt_changed,
+  MigrationEvent.zoom_changed,
+  MigrationEvent.drag,
+  MigrationEvent.dragend,
+  MigrationEvent.dragstart,
 ];
+
+// List of Google Marker Events that are supported by MapLibre Markers that include the MapMouseEvent parameter
+export const GoogleMarkerMouseEvent = [MigrationEvent.drag, MigrationEvent.dragstart, MigrationEvent.dragend];
+
+// List of Google Marker Events that are not supported by MapLibre Markers that include the MapMouseEvent parameter
+// (must add event listener using DOM element)
+export const GoogleMarkerMouseDOMEvent = [MigrationEvent.click, MigrationEvent.dblclick, MigrationEvent.contextmenu];
 
 export interface QueryAutocompletePrediction {
   description: string;

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -8,7 +8,7 @@ import {
   GoogleMapEvent,
   GoogleMapMouseEvent,
   GoogleToMaplibreControlPosition,
-  GoogleToMaplibreMapEvent,
+  GoogleToMaplibreEvent,
   LatLngToLngLat,
 } from "./googleCommon";
 
@@ -74,7 +74,7 @@ class MigrationMap {
 
   addListener(eventName, handler) {
     if (GoogleMapMouseEvent.includes(eventName)) {
-      this.#map.on(GoogleToMaplibreMapEvent[eventName], (mapLibreMapMouseEvent) => {
+      this.#map.on(GoogleToMaplibreEvent[eventName], (mapLibreMapMouseEvent) => {
         const googleMapMouseEvent = {
           domEvent: mapLibreMapMouseEvent.originalEvent,
           latLng: GoogleLatLng(mapLibreMapMouseEvent.lngLat.lat, mapLibreMapMouseEvent.lngLat.lng),
@@ -82,7 +82,7 @@ class MigrationMap {
         handler(googleMapMouseEvent);
       });
     } else if (GoogleMapEvent.includes(eventName)) {
-      this.#map.on(GoogleToMaplibreMapEvent[eventName], () => {
+      this.#map.on(GoogleToMaplibreEvent[eventName], () => {
         handler();
       });
     }

--- a/test/markers.test.ts
+++ b/test/markers.test.ts
@@ -3,6 +3,7 @@
 
 import { MigrationMap } from "../src/maps";
 import { MigrationMarker } from "../src/markers";
+import { GoogleLatLng } from "../src/googleCommon";
 
 // Mock maplibre because it requires a valid DOM container to create a Map
 // We don't need to verify maplibre itself, we just need to verify that
@@ -364,4 +365,241 @@ test("should call remove from marker", () => {
   testMarker.remove();
 
   expect(Marker.prototype.remove).toHaveBeenCalledTimes(1);
+});
+
+test("should call handler with translated MouseEvent after drag", () => {
+  // mock marker so that we can mock on so that we can mock drag
+  const mockMarker = {
+    on: jest.fn(),
+    getLngLat: jest.fn().mockReturnValue(GoogleLatLng(1, 2)),
+  };
+  const migrationMarker = new MigrationMarker({});
+  migrationMarker._setMarker(mockMarker);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMarker.addListener("drag", handlerSpy);
+
+  // mock drag
+  const mockMapLibreMouseEvent = {
+    target: {},
+    type: "drag",
+  };
+  mockMarker.on.mock.calls[0][1](mockMapLibreMouseEvent);
+
+  // expected translated MouseEvent (Google's version)
+  const expectedGoogleMouseEvent = {
+    domEvent: {
+      target: {},
+      type: "drag",
+    },
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMouseEvent);
+});
+
+test("should call handler with translated MouseEvent after dragstart", () => {
+  // mock marker so that we can mock on so that we can mock dragstart
+  const mockMarker = {
+    on: jest.fn(),
+    getLngLat: jest.fn().mockReturnValue(GoogleLatLng(1, 2)),
+  };
+  const migrationMarker = new MigrationMarker({});
+  migrationMarker._setMarker(mockMarker);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMarker.addListener("dragstart", handlerSpy);
+
+  // mock dragstart
+  const mockMapLibreMouseEvent = {
+    target: {},
+    type: "dragstart",
+  };
+  mockMarker.on.mock.calls[0][1](mockMapLibreMouseEvent);
+
+  // expected translated MouseEvent (Google's version)
+  const expectedGoogleMouseEvent = {
+    domEvent: {
+      target: {},
+      type: "dragstart",
+    },
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMouseEvent);
+});
+
+test("should call handler with translated MouseEvent after dragend", () => {
+  // mock marker so that we can mock on so that we can mock dragend
+  const mockMarker = {
+    on: jest.fn(),
+    getLngLat: jest.fn().mockReturnValue(GoogleLatLng(1, 2)),
+  };
+  const migrationMarker = new MigrationMarker({});
+  migrationMarker._setMarker(mockMarker);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMarker.addListener("dragend", handlerSpy);
+
+  // mock dragend
+  const mockMapLibreMouseEvent = {
+    target: {},
+    type: "dragend",
+  };
+  mockMarker.on.mock.calls[0][1](mockMapLibreMouseEvent);
+
+  // expected translated MouseEvent (Google's version)
+  const expectedGoogleMouseEvent = {
+    domEvent: {
+      target: {},
+      type: "dragend",
+    },
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMouseEvent);
+});
+
+test("should call handler with translated MouseEvent after click", () => {
+  // mock element so that we can mock addEventListener so that we can mock click
+  const mockElement = {
+    addEventListener: jest.fn(),
+  };
+
+  // mock marker to return mockElement when getElement is called
+  const mockMarker = {
+    getElement: jest.fn().mockReturnValue(mockElement),
+    getLngLat: jest.fn().mockReturnValue(GoogleLatLng(1, 2)),
+  };
+  const migrationMarker = new MigrationMarker({});
+  migrationMarker._setMarker(mockMarker);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMarker.addListener("click", handlerSpy);
+
+  // mock click
+  const mockMapLibreMouseEvent = {
+    target: {},
+    type: "click",
+    stopPropagation: jest.fn().mockReturnValue(null),
+  };
+  mockElement.addEventListener.mock.calls[0][1](mockMapLibreMouseEvent);
+
+  // expected translated MouseEvent (Google's version)
+  const expectedGoogleMouseEvent = {
+    domEvent: {
+      target: {},
+      type: "click",
+      stopPropagation: expect.any(Function),
+    },
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMouseEvent);
+});
+
+test("should call handler with translated MouseEvent after dblclick", () => {
+  // mock element so that we can mock addEventListener so that we can mock dblclick
+  const mockElement = {
+    addEventListener: jest.fn(),
+  };
+
+  // mock marker to return mockElement when getElement is called
+  const mockMarker = {
+    getElement: jest.fn().mockReturnValue(mockElement),
+    getLngLat: jest.fn().mockReturnValue(GoogleLatLng(1, 2)),
+  };
+  const migrationMarker = new MigrationMarker({});
+  migrationMarker._setMarker(mockMarker);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMarker.addListener("dblclick", handlerSpy);
+
+  // mock dblclick
+  const mockMapLibreMouseEvent = {
+    target: {},
+    type: "dblclick",
+    stopPropagation: jest.fn().mockReturnValue(null),
+  };
+  mockElement.addEventListener.mock.calls[0][1](mockMapLibreMouseEvent);
+
+  // expected translated MouseEvent (Google's version)
+  const expectedGoogleMouseEvent = {
+    domEvent: {
+      target: {},
+      type: "dblclick",
+      stopPropagation: expect.any(Function),
+    },
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMouseEvent);
+});
+
+test("should call handler with translated MouseEvent after contextmenu", () => {
+  // mock element so that we can mock addEventListener so that we can mock contextmenu
+  const mockElement = {
+    addEventListener: jest.fn(),
+  };
+
+  // mock marker to return mockElement when getElement is called
+  const mockMarker = {
+    getElement: jest.fn().mockReturnValue(mockElement),
+    getLngLat: jest.fn().mockReturnValue(GoogleLatLng(1, 2)),
+  };
+  const migrationMarker = new MigrationMarker({});
+  migrationMarker._setMarker(mockMarker);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  migrationMarker.addListener("contextmenu", handlerSpy);
+
+  // mock contextmenu
+  const mockMapLibreMouseEvent = {
+    target: {},
+    type: "contextmenu",
+    stopPropagation: jest.fn().mockReturnValue(null),
+  };
+  mockElement.addEventListener.mock.calls[0][1](mockMapLibreMouseEvent);
+
+  // expected translated MouseEvent (Google's version)
+  const expectedGoogleMouseEvent = {
+    domEvent: {
+      target: {},
+      type: "contextmenu",
+      stopPropagation: expect.any(Function),
+    },
+    latLng: {
+      lat: expect.any(Function),
+      lng: expect.any(Function),
+    },
+  };
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+  expect(handlerSpy).toHaveBeenCalledWith(expectedGoogleMouseEvent);
 });


### PR DESCRIPTION
- Implemented `drag`, `dragstart`, and `dragend` events (MapLibre supported) using MapLibre Marker's `on` method
- Implemented `click`, `dblclick`, and `contextmenu` events (MapLibre does not support) by leveraging marker DOM element's `addEventListener` fuction
- Added Marker events to google common file (googleCommon.ts)
- Refactored google common file so that `GoogleToMaplibreMapEvent` is now more generalized to `GoogleToMaplibreEvent` to account for Map events as well as Marker events