### PR TITLE
Switch the adapter to standalone mode

### DIFF
--- a/examples/autoComplete/example.js
+++ b/examples/autoComplete/example.js
@@ -147,8 +147,8 @@ function createMarker(place) {
 
   markers.push(marker);
 
-  // TODO: Add support for re-routing these event listeners to our MapLibre markers
-  google.maps.event.addListener(marker, "click", () => {
+  // TODO: Update this example to display an InfoWindow when clicking on the marker to display additional details (from getDetails)
+  marker.addListener(marker, "click", () => {
     console.log("MARKER CLICKED", place.name);
   });
 }

--- a/examples/autoComplete/index.template.html
+++ b/examples/autoComplete/index.template.html
@@ -10,9 +10,6 @@
 
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
-
-    <!-- Migration script import -->
-    <script src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
   </head>
   <body>
     <!-- Search box and map elements for the example -->
@@ -21,10 +18,11 @@
     </div>
     <div id="map"></div>
 
-    <!-- Google Maps API import -->
+    <!-- Migration script import -->
     <script
+      async
       defer
-      src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&callback=migrationInit&libraries=places"
+      src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/examples/basicMap/index.template.html
+++ b/examples/basicMap/index.template.html
@@ -5,18 +5,16 @@
 
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
-
-    <!-- Migration script import -->
-    <script src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
   </head>
   <body>
     <!-- Map element -->
     <div id="map"></div>
 
-    <!-- Google Maps API import -->
+    <!-- Migration script import -->
     <script
+      async
       defer
-      src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&callback=migrationInit&libraries=places"
+      src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/examples/directions/index.template.html
+++ b/examples/directions/index.template.html
@@ -5,9 +5,6 @@
 
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
-
-    <!-- Migration script import -->
-    <script src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&routeCalculator={{ROUTE_CALCULATOR}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
   </head>
   <body>
     <div id="floating-panel">
@@ -44,11 +41,11 @@
     </div>
     <div id="map"></div>
 
-    <!-- Google Maps API import -->
+    <!-- Migration script import -->
     <script
       async
       defer
-      src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&callback=migrationInit&libraries=places"
+      src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&routeCalculator={{ROUTE_CALCULATOR}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/examples/markers/index.template.html
+++ b/examples/markers/index.template.html
@@ -5,18 +5,16 @@
 
     <!-- Client logic example -->
     <script type="text/javascript" src="./example.js"></script>
-
-    <!-- Migration script import -->
-    <script src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
   </head>
   <body>
     <!-- Map element -->
     <div id="map"></div>
 
-    <!-- Google Maps API import -->
+    <!-- Migration script import -->
     <script
+      async
       defer
-      src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&callback=migrationInit&libraries=places,marker"
+      src="../../dist/amazonLocationMigrationAdapter.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -273,6 +273,14 @@ export const PlacesServiceStatus = {
   NOT_FOUND: "NOT_FOUND",
 };
 
+export const TravelMode = {
+  DRIVING: "DRIVING",
+  WALKING: "WALKING",
+  BICYCLING: "BICYCLING",
+  TRANSIT: "TRANSIT",
+  TWO_WHEELER: "TWO_WHEELER",
+};
+
 export const DirectionsStatus = {
   OK: "OK",
   UNKNOWN_ERROR: "UNKNOWN_ERROR",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Setup fake HTMLScriptElement so that our unit test can simulate the migration adapter
+// retrieving its configuration from the URLSearchParams
+const testAPIKey = "123456789";
+const testMapName = "TestMap";
+const testPlaceIndex = "TestPlaceIndex";
+const testRouteCalculator = "TestRouteCalculator";
+const testCallback = "testCallback";
+const testCurrentScript = document.createElement("src") as HTMLScriptElement;
+testCurrentScript.src = `amazonLocationMigrationAdapter.js?callback=${testCallback}&map=${testMapName}&placeIndex=${testPlaceIndex}&routeCalculator=${testRouteCalculator}&apiKey=${testAPIKey}`;
+
+// Override the document.currentScript with our fake HTMLScriptElement
+Object.defineProperty(document, "currentScript", {
+  value: testCurrentScript,
+});
+
+// Create a mock callback function so we can verify the migration adapter calls it after loading
+const mockMigrationCallback = jest.fn();
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+(window as any)[testCallback] = mockMigrationCallback;
+
+// Import the migration adapter after our mock script HTMLScriptElement has been setup
+import "../src/index";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("importing the adapter should populate google.maps namespace for direct loading", () => {
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const google = (window as any).google;
+
+  // Core classes
+  expect(google.maps).toHaveProperty("LatLng");
+  expect(google.maps).toHaveProperty("LatLngBounds");
+
+  // Maps and controls (e.g. Markers)
+  expect(google.maps).toHaveProperty("Map");
+  expect(google.maps).toHaveProperty("Marker");
+  expect(google.maps.marker).toHaveProperty("AdvancedMarkerElement");
+
+  // Directions classes
+  expect(google.maps).toHaveProperty("DirectionsRenderer");
+  expect(google.maps).toHaveProperty("DirectionsService");
+  expect(google.maps).toHaveProperty("DirectionsStatus");
+  expect(google.maps).toHaveProperty("TravelMode");
+
+  // Places classes
+  expect(google.maps.places).toHaveProperty("AutocompleteService");
+  expect(google.maps.places).toHaveProperty("PlacesService");
+  expect(google.maps.places).toHaveProperty("PlacesServiceStatus");
+
+  // Verify our mock callback has been invoked after loading the adapter
+  expect(mockMigrationCallback).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Description
Changed the adapter to operate in standalone mode, instead of first loading the Google API and then overriding the classes we support.
* The adapter now creates the `google.maps` namespace and then populates it with the classes we currently support, instead of expecting the `google.maps` namespace to already exist and override the classes we support
* Updated all examples `index.template.html` to only import our migration adapter, and have them match the same way way we import the Google API in the Google examples
* Added unit test to test importing the adapter (able to get 100% coverage on `index.ts`

## Testing
Ran unit tests and verified they all passed:

```
------------------|---------|----------|---------|---------|--------------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|--------------------------
All files         |   82.94 |    84.64 |   81.05 |      83 |
 directions.ts    |    9.25 |        0 |       0 |    7.69 | 26-204
 google.maps.d.ts |       0 |        0 |       0 |       0 |
 googleCommon.ts  |     100 |      100 |     100 |     100 |
 index.ts         |     100 |      100 |     100 |     100 |
 maps.ts          |     100 |    97.26 |     100 |     100 | 105
 markers.ts       |   78.66 |    66.66 |      90 |   78.66 | 63-68,88-115,140,310-334
 places.ts        |   81.19 |       84 |      75 |   81.03 | 230-278
------------------|---------|----------|---------|---------|--------------------------

Test Suites: 5 passed, 5 total
Tests:       100 passed, 100 total
```

Also built/ran the examples and verified they work as expected.