### PR TITLE
Added PolylineOptions for DirectionsRenderer

### DIFF
--- a/src/directions.ts
+++ b/src/directions.ts
@@ -121,6 +121,7 @@ class MigrationDirectionsRenderer {
   #markers: MigrationMarker[];
   #map: MigrationMap;
   #markerOptions;
+  #polylineOptions;
   #preserveViewport = false;
   #suppressMarkers = false;
   #suppressPolylines = false;
@@ -150,6 +151,10 @@ class MigrationDirectionsRenderer {
 
     if (options !== undefined && "suppressPolylines" in options) {
       this.#suppressPolylines = options.suppressPolylines;
+    }
+
+    if (options !== undefined && "polylineOptions" in options) {
+      this.#polylineOptions = options.polylineOptions;
     }
   }
 
@@ -204,6 +209,22 @@ class MigrationDirectionsRenderer {
             },
           },
         });
+        // 8 weight, 0.5 opacity, "#73B9FF" color for default, 3 weight, 1 opacity, "Black" color used when one property is set
+        const paintOptions = {};
+        if (this.#polylineOptions) {
+          paintOptions["line-color"] = this.#polylineOptions.strokeColor ? this.#polylineOptions.strokeColor : "Black";
+          paintOptions["line-width"] = this.#polylineOptions.strokeWeight ? this.#polylineOptions.strokeWeight : 3;
+          paintOptions["line-opacity"] = this.#polylineOptions.strokeOpacity ? this.#polylineOptions.strokeOpacity : 1;
+          if (this.#polylineOptions.visible == false) {
+            paintOptions["visibility"] = "none";
+          }
+        } else {
+          // default line
+          paintOptions["line-color"] = "#73B9FF";
+          paintOptions["line-width"] = 8;
+          paintOptions["line-opacity"] = 0.5;
+        }
+
         maplibreMap.addLayer({
           id: "route",
           type: "line",
@@ -212,11 +233,7 @@ class MigrationDirectionsRenderer {
             "line-join": "round",
             "line-cap": "round",
           },
-          paint: {
-            "line-color": "#73B9FF",
-            "line-width": 8,
-            "line-opacity": 0.5,
-          },
+          paint: paintOptions,
         });
       }
 

--- a/test/directions.test.ts
+++ b/test/directions.test.ts
@@ -235,3 +235,196 @@ test("should call setDirections method on directionsrenderer twice", () => {
   expect(Marker).toHaveBeenCalledTimes(4);
   expect(testDirectionsRenderer._getMarkers().length).toBe(2);
 });
+
+test("should call setDirections method on directionsrenderer with all polylineOptions set", () => {
+  globalThis.structuredClone = jest.fn().mockReturnValue({});
+
+  const testMap = new MigrationMap(null, {
+    center: { lat: testLat, lng: testLng },
+    zoom: 9,
+  });
+  const testDirectionsRenderer = new MigrationDirectionsRenderer({
+    map: testMap,
+    markerOptions: {},
+    polylineOptions: {
+      strokeColor: "Blue",
+      strokeWeight: 10,
+      strokeOpacity: 0.1,
+      visible: false,
+    },
+  });
+
+  testDirectionsRenderer.setDirections({
+    routes: [
+      {
+        bounds: null,
+        legs: [
+          {
+            geometry: {
+              LineString: 0,
+            },
+            start_location: { lat: 0, lng: 0 },
+            end_location: { lat: 1, lng: 1 },
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(Map.prototype.addSource).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.addSource).toHaveBeenCalledWith("route", {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: 0,
+      },
+    },
+  });
+  expect(Map.prototype.addLayer).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.addLayer).toHaveBeenCalledWith({
+    id: "route",
+    type: "line",
+    source: "route",
+    layout: {
+      "line-join": "round",
+      "line-cap": "round",
+    },
+    paint: {
+      "line-color": "Blue",
+      "line-width": 10,
+      "line-opacity": 0.1,
+      visibility: "none",
+    },
+  });
+  expect(Marker).toHaveBeenCalledTimes(2);
+  expect(testDirectionsRenderer._getMarkers().length).toBe(2);
+});
+
+test("should call setDirections method on directionsrenderer with polylineOptions strokeColor set", () => {
+  globalThis.structuredClone = jest.fn().mockReturnValue({});
+
+  const testMap = new MigrationMap(null, {
+    center: { lat: testLat, lng: testLng },
+    zoom: 9,
+  });
+  const testDirectionsRenderer = new MigrationDirectionsRenderer({
+    map: testMap,
+    markerOptions: {},
+    polylineOptions: {
+      strokeColor: "Red",
+    },
+  });
+
+  testDirectionsRenderer.setDirections({
+    routes: [
+      {
+        bounds: null,
+        legs: [
+          {
+            geometry: {
+              LineString: 0,
+            },
+            start_location: { lat: 0, lng: 0 },
+            end_location: { lat: 1, lng: 1 },
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(Map.prototype.addSource).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.addSource).toHaveBeenCalledWith("route", {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: 0,
+      },
+    },
+  });
+  expect(Map.prototype.addLayer).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.addLayer).toHaveBeenCalledWith({
+    id: "route",
+    type: "line",
+    source: "route",
+    layout: {
+      "line-join": "round",
+      "line-cap": "round",
+    },
+    paint: {
+      "line-color": "Red",
+      "line-width": 3,
+      "line-opacity": 1,
+    },
+  });
+  expect(Marker).toHaveBeenCalledTimes(2);
+  expect(testDirectionsRenderer._getMarkers().length).toBe(2);
+});
+
+test("should call setDirections method on directionsrenderer with polylineOptions strokeWeight set", () => {
+  globalThis.structuredClone = jest.fn().mockReturnValue({});
+
+  const testMap = new MigrationMap(null, {
+    center: { lat: testLat, lng: testLng },
+    zoom: 9,
+  });
+  const testDirectionsRenderer = new MigrationDirectionsRenderer({
+    map: testMap,
+    markerOptions: {},
+    polylineOptions: {
+      strokeWeight: 1,
+    },
+  });
+
+  testDirectionsRenderer.setDirections({
+    routes: [
+      {
+        bounds: null,
+        legs: [
+          {
+            geometry: {
+              LineString: 0,
+            },
+            start_location: { lat: 0, lng: 0 },
+            end_location: { lat: 1, lng: 1 },
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(Map.prototype.addSource).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.addSource).toHaveBeenCalledWith("route", {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: 0,
+      },
+    },
+  });
+  expect(Map.prototype.addLayer).toHaveBeenCalledTimes(1);
+  expect(Map.prototype.addLayer).toHaveBeenCalledWith({
+    id: "route",
+    type: "line",
+    source: "route",
+    layout: {
+      "line-join": "round",
+      "line-cap": "round",
+    },
+    paint: {
+      "line-color": "Black",
+      "line-width": 1,
+      "line-opacity": 1,
+    },
+  });
+  expect(Marker).toHaveBeenCalledTimes(2);
+  expect(testDirectionsRenderer._getMarkers().length).toBe(2);
+});


### PR DESCRIPTION
- Added PolylineOptions `strokeColor`, `strokeWeight`, `strokeOpacity`, and `visible` along with unit tests
- Originally planned to add `clickable`, but after further research, it looks like the Polyline that the DirectionsRenderer creates is not accessible, and so a customer would not be able to add an eventListener to leverage the clickable option
- Also originally planned to add `draggable` option, but the use-case for dragging a polyline that the DirectionsRenderer renders is seemingly small
