### PR TITLE
Added Marker support for rotate and scale customization

### DIFF
--- a/examples/markers/example.js
+++ b/examples/markers/example.js
@@ -62,7 +62,8 @@ function initMap() {
     fillOpacity: 0.6,
     strokeWeight: 2,
     strokeColor: "green",
-    rotation: 0,
+    rotation: 45,
+    scale: 1.337,
   };
   new google.maps.Marker({
     position: { lat: 30.25, lng: -97.85 },

--- a/src/markers.ts
+++ b/src/markers.ts
@@ -35,7 +35,7 @@ class MigrationMarker {
     // handles:
     // - url parameter
     // - simple icon interface parameter (no customizability),
-    // - svg parameter (Symbol) excluding anchor, rotation, and scale customizability properties
+    // - svg parameter (Symbol) excluding anchor
     if (options.icon) {
       if (typeof options.icon === "object") {
         if ("url" in options.icon) {
@@ -48,15 +48,39 @@ class MigrationMarker {
         } else if ("path" in options.icon) {
           const imgContainer = document.createElement("div");
           imgContainer.classList.add("non-default-legacy-marker");
+
+          // Container svg element
           const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+          // Child element to store the path, which is required a required option
           const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
           path.setAttribute("d", options.icon.path);
-          path.setAttribute("fill", options.icon.fillColor);
-          path.setAttribute("fill-opacity", options.icon.fillOpacity);
-          path.setAttribute("stroke", options.icon.strokeColor);
-          path.setAttribute("stroke-width", options.icon.strokeWeight);
-          path.setAttribute("stroke-opacity", options.icon.strokeOpacity);
+
+          // Set optional attributes for the path
+          // Default values from https://developers.google.com/maps/documentation/javascript/symbols#properties
+          const scale = options.icon.scale || 1.0;
+          path.setAttribute("fill", options.icon.fillColor || "black");
+          path.setAttribute("fill-opacity", options.icon.fillOpacity || 0.0);
+          path.setAttribute("stroke", options.icon.strokeColor || "black");
+          path.setAttribute("stroke-width", options.icon.strokeWeight || scale);
+          path.setAttribute("stroke-opacity", options.icon.strokeOpacity || 1.0);
+
           svg.appendChild(path);
+
+          // Collect the rotation and scale options (if specified) into single transform line
+          let transform = "";
+          if (options.icon.rotation) {
+            transform = `rotate(${options.icon.rotation})`;
+          }
+          if (scale !== 1.0) {
+            transform += ` scale(${scale})`;
+          }
+
+          // Set the transform attribute, if any overrides were specified
+          if (transform) {
+            svg.setAttribute("transform", transform);
+          }
+
           imgContainer.appendChild(svg);
           maplibreOptions.element = imgContainer;
           svg.addEventListener("load", () => {

--- a/test/markers.test.ts
+++ b/test/markers.test.ts
@@ -119,7 +119,8 @@ test("should set marker with symbol object", () => {
     fillOpacity: 0.6,
     strokeWeight: 2,
     strokeColor: "green",
-    rotation: 0,
+    rotation: 45,
+    scale: 2,
   };
   new MigrationMarker({
     icon: svgMarker,
@@ -134,7 +135,36 @@ test("should set marker with symbol object", () => {
   path.setAttribute("fill-opacity", "0.6");
   path.setAttribute("stroke", "green");
   path.setAttribute("stroke-width", "2");
-  path.setAttribute("stroke-opacity", "undefined");
+  path.setAttribute("stroke-opacity", "1");
+  svg.appendChild(path);
+  svg.setAttribute("transform", "rotate(45) scale(2)");
+  imageContainer.appendChild(svg);
+  const expectedMaplibreOptions: MarkerOptions = {
+    element: imageContainer,
+  };
+
+  expect(Marker).toHaveBeenCalledTimes(1);
+  expect(Marker).toHaveBeenCalledWith(expectedMaplibreOptions);
+});
+
+test("should set marker with symbol with default attributes", () => {
+  const svgMarker = {
+    path: "M 0 25 L 25 25 L 12.5 0 Z",
+  };
+  new MigrationMarker({
+    icon: svgMarker,
+  });
+
+  const imageContainer = document.createElement("div");
+  imageContainer.className = "non-default-legacy-marker";
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("d", "M 0 25 L 25 25 L 12.5 0 Z");
+  path.setAttribute("fill", "black");
+  path.setAttribute("fill-opacity", "0");
+  path.setAttribute("stroke", "black");
+  path.setAttribute("stroke-width", "1");
+  path.setAttribute("stroke-opacity", "1");
   svg.appendChild(path);
   imageContainer.appendChild(svg);
   const expectedMaplibreOptions: MarkerOptions = {


### PR DESCRIPTION
## Description
Added support for `rotation` and `scale` options on custom symbol `Marker`.
* Custom `Marker` can now be rotated and scaled
* Updated other properties to have default values as specified in https://developers.google.com/maps/documentation/javascript/symbols#properties
* Stroke weight now uses scale as default if none was specified

## Testing
Updated the `markers` example to rotate and scale its custom symbol Marker example. Also updated marker unit tests for added logic and built/ran unit tests.