### PR TITLE
Refactored route method to handle multiple input types

### DIFF
--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -3,12 +3,12 @@
 
 import { LngLatBounds } from "maplibre-gl";
 
-interface LatLngLiteral {
+export interface LatLngLiteral {
   lat: number;
   lng: number;
 }
 
-type LatLngLike = LatLngLiteral | MigrationLatLng;
+export type LatLngLike = LatLngLiteral | MigrationLatLng;
 
 interface LatLngBoundsLiteral {
   east: number;
@@ -273,24 +273,24 @@ export const PlacesServiceStatus = {
   NOT_FOUND: "NOT_FOUND",
 };
 
-export const TravelMode = {
-  DRIVING: "DRIVING",
-  WALKING: "WALKING",
-  BICYCLING: "BICYCLING",
-  TRANSIT: "TRANSIT",
-  TWO_WHEELER: "TWO_WHEELER",
-};
+export enum TravelMode {
+  DRIVING = "DRIVING",
+  WALKING = "WALKING",
+  BICYCLING = "BICYCLING",
+  TRANSIT = "TRANSIT",
+  TWO_WHEELER = "TWO_WHEELER",
+}
 
-export const DirectionsStatus = {
-  OK: "OK",
-  UNKNOWN_ERROR: "UNKNOWN_ERROR",
-  OVER_QUERY_LIMIT: "OVER_QUERY_LIMIT",
-  REQUEST_DENIED: "REQUEST_DENIED",
-  INVALID_REQUEST: "INVALID_REQUEST",
-  ZERO_RESULTS: "ZERO_RESULTS",
-  MAX_WAYPOINTS_EXCEEDED: "MAX_WAYPOINTS_EXCEEDED",
-  NOT_FOUND: "NOT_FOUND",
-};
+export enum DirectionsStatus {
+  OK = "OK",
+  UNKNOWN_ERROR = "UNKNOWN_ERROR",
+  OVER_QUERY_LIMIT = "OVER_QUERY_LIMIT",
+  REQUEST_DENIED = "REQUEST_DENIED",
+  INVALID_REQUEST = "INVALID_REQUEST",
+  ZERO_RESULTS = "ZERO_RESULTS",
+  MAX_WAYPOINTS_EXCEEDED = "MAX_WAYPOINTS_EXCEEDED",
+  NOT_FOUND = "NOT_FOUND",
+}
 
 // Migration version of google.maps.ControlPosition
 // This is only used in adapter standalone mode and in unit tests

--- a/src/places.ts
+++ b/src/places.ts
@@ -376,6 +376,10 @@ class MigrationAutocomplete {
       geocoder.container.className = `${inputField.className} ${geocoder.container.className}`;
     }
 
+    if (inputField.id) {
+      geocoder._inputEl.id = inputField.id;
+    }
+
     inputField.remove();
 
     if (opts) {
@@ -511,6 +515,10 @@ class MigrationSearchBox {
 
     if (inputField.className) {
       geocoder.container.className = `${inputField.className} ${geocoder.container.className}`;
+    }
+
+    if (inputField.id) {
+      geocoder._inputEl.id = inputField.id;
     }
 
     inputField.remove();

--- a/test/directions.test.ts
+++ b/test/directions.test.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MigrationMap } from "../src/maps";
-import { MigrationDirectionsRenderer } from "../src/directions";
+import { MigrationDirectionsRenderer, MigrationDirectionsService } from "../src/directions";
+import { MigrationPlacesService } from "../src/places";
+import { DirectionsStatus, MigrationLatLng, MigrationLatLngBounds, TravelMode } from "../src/googleCommon";
 
 const mockAddControl = jest.fn();
 const mockFitBounds = jest.fn();
@@ -36,6 +38,148 @@ jest.mock("maplibre-gl", () => ({
     };
   }),
 }));
+
+const clientErrorQuery = "THIS_WILL_CAUSE_A_CLIENT_ERROR";
+const clientErrorPlaceId = "INVALID_PLACE_ID";
+const clientErrorDestinationPosition = [-1, -1];
+const testCoolPlaceLocation = new MigrationLatLng(3, 4);
+const testAnotherCoolPlaceLocation = new MigrationLatLng(7, 8);
+
+const mockedClientSend = jest.fn((command) => {
+  return new Promise((resolve, reject) => {
+    if (command instanceof CalculateRouteCommand) {
+      if (JSON.stringify(command.input.DestinationPosition) == JSON.stringify(clientErrorDestinationPosition)) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        const startPosition = command.input.DeparturePosition as number[];
+        const endPosition = command.input.DestinationPosition as number[];
+
+        resolve({
+          Legs: [
+            {
+              Distance: 9001,
+              DurationSeconds: 1337,
+              EndPosition: endPosition,
+              Geometry: {
+                LineString: [
+                  [0, 0],
+                  [1, 1],
+                  [2, 2],
+                ],
+              },
+              StartPosition: startPosition,
+              Steps: [
+                {
+                  Distance: 3,
+                  DurationSeconds: 5,
+                  EndPosition: [3, 4],
+                  StartPosition: [1, 2],
+                },
+                {
+                  Distance: 4,
+                  DurationSeconds: 6,
+                  EndPosition: [6, 7],
+                  StartPosition: [3, 4],
+                },
+                {
+                  Distance: 10,
+                  DurationSeconds: 7,
+                  EndPosition: [20, 21],
+                  StartPosition: [6, 7],
+                },
+              ],
+            },
+          ],
+          Summary: {
+            Distance: 9001,
+            DistanceUnit: "Kilometers",
+            DurationSeconds: 1337,
+            RouteBBox: startPosition.concat(endPosition),
+          },
+        });
+      }
+    } else if (command instanceof SearchPlaceIndexForTextCommand) {
+      if (command.input.Text == clientErrorQuery) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else if (command.input.Text == "cool place") {
+        resolve({
+          Results: [
+            {
+              Place: {
+                Label: "cool place, austin, tx",
+                Geometry: {
+                  Point: [testCoolPlaceLocation.lng(), testCoolPlaceLocation.lat()],
+                },
+              },
+              PlaceId: "KEEP_AUSTIN_WEIRD",
+            },
+          ],
+        });
+      } else if (command.input.Text == "another cool place") {
+        resolve({
+          Results: [
+            {
+              Place: {
+                Label: "another cool place, austin, tx",
+                Geometry: {
+                  Point: [testAnotherCoolPlaceLocation.lng(), testAnotherCoolPlaceLocation.lat()],
+                },
+              },
+              PlaceId: "ANOTHER_COOL_PLACE",
+            },
+          ],
+        });
+      }
+    } else if (command instanceof GetPlaceCommand) {
+      if (command.input.PlaceId === clientErrorPlaceId) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        resolve({
+          Place: {
+            Label: "cool place, austin, tx",
+            AddressNumber: "1337",
+            Street: "Cool Place Road",
+            Geometry: {
+              Point: [testCoolPlaceLocation.lng(), testCoolPlaceLocation.lat()],
+            },
+            TimeZone: {
+              Offset: -18000,
+            },
+            Municipality: "Austin",
+          },
+        });
+      }
+    } else {
+      reject();
+    }
+  });
+});
+
+jest.mock("@aws-sdk/client-location", () => ({
+  ...jest.requireActual("@aws-sdk/client-location"),
+  LocationClient: jest.fn().mockImplementation(() => {
+    return {
+      send: mockedClientSend,
+    };
+  }),
+}));
+import {
+  LocationClient,
+  CalculateRouteCommand,
+  GetPlaceCommand,
+  SearchPlaceIndexForTextCommand,
+} from "@aws-sdk/client-location";
+
+const directionsService = new MigrationDirectionsService();
+directionsService._client = new LocationClient();
+
+// The DirectionsService also uses the PlacesService in cases where the route is specified with a query string
+// or PlaceId, so we need to set up a mocked one here.
+MigrationPlacesService.prototype._client = new LocationClient();
+directionsService._placesService = new MigrationPlacesService();
 
 // Mock maplibre because it requires a valid DOM container to create a Map
 // We don't need to verify maplibre itself, we just need to verify that
@@ -491,6 +635,49 @@ test("should call getDirections method on directionsrenderer", () => {
   expect(result).toBe(directions);
 });
 
+test("should not allow calling setDirections with multiple routes", () => {
+  // TODO: This test can be removed in the future once/if we support multiple routes
+  const testMap = new MigrationMap(null, {
+    center: { lat: testLat, lng: testLng },
+    zoom: 9,
+  });
+  const testDirectionsRenderer = new MigrationDirectionsRenderer({
+    map: testMap,
+  });
+  const directions = {
+    routes: [
+      {
+        bounds: null,
+        legs: [
+          {
+            geometry: {
+              LineString: 0,
+            },
+            start_location: { lat: 0, lng: 0 },
+            end_location: { lat: 1, lng: 1 },
+          },
+        ],
+      },
+      {
+        bounds: null,
+        legs: [
+          {
+            geometry: {
+              LineString: 0,
+            },
+            start_location: { lat: 0, lng: 0 },
+            end_location: { lat: 1, lng: 1 },
+          },
+        ],
+      },
+    ],
+  };
+
+  testDirectionsRenderer.setDirections(directions);
+
+  expect(testDirectionsRenderer.getDirections()).toBeUndefined();
+});
+
 test("should call addEventListener method on directionsrenderer", () => {
   const testMap = new MigrationMap(null, {
     center: { lat: testLat, lng: testLng },
@@ -520,4 +707,288 @@ test("should call addEventListener method on directionsrenderer", () => {
 
   testDirectionsRenderer.setDirections(directions);
   expect(handlerSpy).toHaveBeenCalledTimes(1);
+});
+
+test("should return route with origin as LatLng and destination as LatLng", (done) => {
+  const origin = new MigrationLatLng(1, 2);
+  const destination = new MigrationLatLng(20, 21);
+
+  const request = {
+    origin: origin,
+    destination: destination,
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    // Since origin and destination are both specified as parseable values, the only mocked
+    // LocationClient call should be the CalculateRouteCommand
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+
+    const routes = response.routes;
+
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+
+    const bounds = route.bounds;
+    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
+
+    const legs = route.legs;
+
+    expect(legs.length).toStrictEqual(1);
+
+    const leg = legs[0];
+
+    expect(leg.steps.length).toStrictEqual(3);
+    expect(leg.start_location.equals(origin)).toStrictEqual(true);
+    expect(leg.end_location.equals(destination)).toStrictEqual(true);
+
+    done();
+  });
+});
+
+test("should return route with origin as LatLng and destination as Place.location", (done) => {
+  const origin = new MigrationLatLng(1, 2);
+  const destination = new MigrationLatLng(20, 21);
+
+  const request = {
+    origin: origin,
+    destination: {
+      location: destination,
+    },
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    // Since origin and destination are both specified as parseable values, the only mocked
+    // LocationClient call should be the CalculateRouteCommand
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+
+    const routes = response.routes;
+
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+
+    const bounds = route.bounds;
+    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
+
+    done();
+  });
+});
+
+test("should return route with origin as Place.location and destination as LatLng", (done) => {
+  const origin = new MigrationLatLng(1, 2);
+  const destination = new MigrationLatLng(20, 21);
+
+  const request = {
+    origin: {
+      location: origin,
+    },
+    destination: destination,
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    // Since origin and destination are both specified as parseable values, the only mocked
+    // LocationClient call should be the CalculateRouteCommand
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+
+    const routes = response.routes;
+
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+
+    const bounds = route.bounds;
+    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
+
+    done();
+  });
+});
+
+test("should return route with origin as Place.location and destination as Place.location", (done) => {
+  const origin = new MigrationLatLng(1, 2);
+  const destination = new MigrationLatLng(20, 21);
+
+  const request = {
+    origin: {
+      location: origin,
+    },
+    destination: {
+      location: destination,
+    },
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    // Since origin and destination are both specified as parseable values, the only mocked
+    // LocationClient call should be the CalculateRouteCommand
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+
+    const routes = response.routes;
+
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+
+    const bounds = route.bounds;
+    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
+
+    done();
+  });
+});
+
+test("should return route with origin as string and destination as Place.query", (done) => {
+  const request = {
+    origin: "cool place",
+    destination: {
+      query: "another cool place",
+    },
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    // Since both origin and destination were query inputs, these will both trigger a
+    // findPlaceFromQuery request to retrieve the location geometry, so there
+    // will be a total of 3 mocked LocationClient.send calls (2 for places, 1 for routes)
+    expect(mockedClientSend).toHaveBeenCalledTimes(3);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+
+    const routes = response.routes;
+
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+
+    const bounds = route.bounds;
+    expect(bounds.equals(new MigrationLatLngBounds(testCoolPlaceLocation, testAnotherCoolPlaceLocation))).toStrictEqual(
+      true,
+    );
+
+    done();
+  });
+});
+
+test("should return route with origin as Place.placeId and destination as Place.query", (done) => {
+  const request = {
+    origin: {
+      placeId: "KEEP_AUSTIN_WEIRD",
+    },
+    destination: {
+      query: "another cool place",
+    },
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    // Since origin was a placeId and destination was a query input, these will trigger a
+    // getDetails and findPlaceFromQuery request (respectively) to retrieve the location geometry,
+    // so there will be a total of 3 mocked LocationClient.send calls (2 for places, 1 for routes)
+    expect(mockedClientSend).toHaveBeenCalledTimes(3);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+
+    const routes = response.routes;
+
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+
+    const bounds = route.bounds;
+    expect(bounds.equals(new MigrationLatLngBounds(testCoolPlaceLocation, testAnotherCoolPlaceLocation))).toStrictEqual(
+      true,
+    );
+
+    done();
+  });
+});
+
+test("route should handle client error", (done) => {
+  const origin = new MigrationLatLng(1, 2);
+  const destination = new MigrationLatLng(-1, -1); // The mock will throw an error for this position
+
+  const request = {
+    origin: origin,
+    destination: destination,
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService
+    .route(request)
+    .then((response) => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(DirectionsStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(1);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("route should handle client error when performing findPlaceFromQuery origin request", (done) => {
+  const request = {
+    origin: clientErrorQuery,
+    destination: {
+      query: "cool place",
+    },
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService
+    .route(request)
+    .then((response) => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(DirectionsStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(2);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("route should handle client error when performing findPlaceFromQuery destination request", (done) => {
+  const request = {
+    origin: "cool place",
+    destination: clientErrorQuery,
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService
+    .route(request)
+    .then((response) => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(DirectionsStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(2);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("route should handle client error when performing getDetails destination request", (done) => {
+  const request = {
+    origin: "cool place",
+    destination: {
+      placeId: clientErrorPlaceId,
+    },
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService
+    .route(request)
+    .then((response) => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(DirectionsStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(2);
+
+      // Signal the unit test is complete
+      done();
+    });
 });

--- a/test/places.test.ts
+++ b/test/places.test.ts
@@ -804,6 +804,18 @@ test("SearchBox created input element will carry-over placeholder if one was set
   expect(geocoder._inputEl.placeholder).toStrictEqual("Test placeholder");
 });
 
+test("SearchBox created input element will carry-over id if one was set", () => {
+  const inputElement = document.createElement("input");
+  inputElement.id = "test-id";
+  document.body.appendChild(inputElement);
+
+  const searchBox = new MigrationSearchBox(inputElement);
+
+  const geocoder = searchBox._getMaplibreGeocoder().getPlacesGeocoder();
+
+  expect(geocoder._inputEl.id).toStrictEqual("test-id");
+});
+
 test("SearchBox created container should transfer className if specified", () => {
   const inputElement = document.createElement("input");
   inputElement.className = "this-is-a-test";
@@ -975,6 +987,18 @@ test("Autocomplete created input element will carry-over placeholder if one was 
   const geocoder = autoComplete._getMaplibreGeocoder().getPlacesGeocoder();
 
   expect(geocoder._inputEl.placeholder).toStrictEqual("Test placeholder");
+});
+
+test("Autocomplete created input element will carry-over id if one was set", () => {
+  const inputElement = document.createElement("input");
+  inputElement.id = "test-id";
+  document.body.appendChild(inputElement);
+
+  const autoComplete = new MigrationAutocomplete(inputElement);
+
+  const geocoder = autoComplete._getMaplibreGeocoder().getPlacesGeocoder();
+
+  expect(geocoder._inputEl.id).toStrictEqual("test-id");
 });
 
 test("Autocomplete created container should transfer className if specified", () => {


### PR DESCRIPTION
## Description
Refactored the `route` method in `DirectionsService` to handle the different origin/destination inputs:
* origin/destination can now be a string to be geocoded, a Place (location/query/placeId), a LatLng or LatLngLiteral
* For the query string and placeId, we perform a `findPlaceFromQuery` or `getDetails`, respectively to retrieve the location
* For LatLng|LatLngLiteral we just parse for the location
* Added several interface types for the directions and its sub-components for ease of use

Also added small change to carry-over the `id` (if specified) for our `Autocomplete` and `SearchBox` widgets.

## Testing
Added unit tests to fully-cover the `route` method and all new logic added (Directions still has a small number of uncovered branches).