### PR TITLE
Implemented the Geocoder class

### DIFF
--- a/src/geocoder.ts
+++ b/src/geocoder.ts
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  LocationClient,
+  SearchPlaceIndexForPositionCommand,
+  SearchPlaceIndexForPositionRequest,
+} from "@aws-sdk/client-location";
+
+import {
+  GeocoderStatus,
+  LatLngLike,
+  LatLngBoundsLike,
+  LatLngToLngLat,
+  MigrationLatLng,
+  PlacesServiceStatus,
+  MigrationLatLngBounds,
+} from "./googleCommon";
+import { convertAmazonPlaceToGoogle, FindPlaceFromQueryRequest, MigrationPlacesService } from "./places";
+
+interface GeocoderRequest {
+  address?: string | null;
+  bounds?: LatLngBoundsLike | null;
+  language?: string | null;
+  location?: LatLngLike | null;
+  placeId?: string | null;
+}
+
+interface GeocoderResponse {
+  results: GeocoderResult[];
+}
+
+interface GeocoderResult {
+  formatted_address: string;
+  geometry: GeocoderGeometry;
+  place_id: string;
+}
+
+interface GeocoderGeometry {
+  bounds?: google.maps.LatLngBounds;
+  location: MigrationLatLng;
+}
+
+class MigrationGeocoder {
+  _client: LocationClient; // This will be populated by the top level module that creates our location client
+  _placeIndexName: string; // This will be populated by the top level module that is passed our place index name
+  // This will be populated by the top level module
+  // that already has a MigrationPlacesService that has
+  // been configured with our place index name
+  _placesService: MigrationPlacesService;
+
+  geocode(request: GeocoderRequest, callback?): Promise<GeocoderResponse> {
+    const bounds = request.bounds;
+    const language = request.language;
+    const location = request.location;
+    const address = request.address;
+    const placeId = request.placeId;
+
+    // These are the only fields we want to return for the GeocoderResult
+    const fields = ["formatted_address", "geometry", "place_id"];
+
+    if (location) {
+      const lngLat = LatLngToLngLat(location);
+      const input: SearchPlaceIndexForPositionRequest = {
+        IndexName: this._placeIndexName, // required
+        Position: lngLat,
+      };
+
+      if (language) {
+        input.Language = language;
+      }
+
+      return new Promise((resolve, reject) => {
+        const command = new SearchPlaceIndexForPositionCommand(input);
+
+        this._client
+          .send(command)
+          .then((response) => {
+            const googleResults = [];
+
+            const results = response.Results;
+            if (results.length !== 0) {
+              results.forEach(function (place) {
+                const newPlace = convertAmazonPlaceToGoogle(place, fields, false);
+
+                googleResults.push(newPlace);
+              });
+            }
+
+            if (callback) {
+              callback(googleResults, GeocoderStatus.OK);
+            }
+
+            resolve({
+              results: googleResults,
+            });
+          })
+          .catch((error) => {
+            console.error(error);
+
+            if (callback) {
+              callback(null, GeocoderStatus.UNKNOWN_ERROR);
+            }
+
+            reject({
+              status: GeocoderStatus.UNKNOWN_ERROR,
+            });
+          });
+      });
+    } else if (placeId) {
+      return new Promise((resolve, reject) => {
+        const request = {
+          placeId: placeId,
+          fields: fields,
+        };
+
+        this._placesService.getDetails(request, (result, status) => {
+          if (status == PlacesServiceStatus.OK) {
+            const googleResults = [result];
+
+            if (callback) {
+              callback(googleResults, GeocoderStatus.OK);
+            }
+
+            resolve({
+              results: googleResults,
+            });
+          } else {
+            if (callback) {
+              callback(null, GeocoderStatus.UNKNOWN_ERROR);
+            }
+
+            reject({
+              status: GeocoderStatus.UNKNOWN_ERROR,
+            });
+          }
+        });
+      });
+    } else if (address) {
+      return new Promise((resolve, reject) => {
+        const request: FindPlaceFromQueryRequest = {
+          query: address,
+          fields: fields,
+        };
+
+        // TODO: findPlaceFromQuery only supports a locationBias instead of a bounds, so if bounds
+        // was specified we will just use the center to act as a locationBias
+        if (bounds) {
+          const latLngBounds = new MigrationLatLngBounds(bounds);
+          request.locationBias = latLngBounds.getCenter();
+        }
+
+        this._placesService.findPlaceFromQuery(request, (results, status) => {
+          if (status == PlacesServiceStatus.OK) {
+            if (callback) {
+              callback(results, GeocoderStatus.OK);
+            }
+
+            resolve({
+              results: results,
+            });
+          } else {
+            if (callback) {
+              callback(null, GeocoderStatus.UNKNOWN_ERROR);
+            }
+
+            reject({
+              status: GeocoderStatus.UNKNOWN_ERROR,
+            });
+          }
+        });
+      });
+    }
+  }
+}
+
+export { GeocoderRequest, MigrationGeocoder };

--- a/src/googleCommon.ts
+++ b/src/googleCommon.ts
@@ -17,6 +17,8 @@ export interface LatLngBoundsLiteral {
   west: number;
 }
 
+export type LatLngBoundsLike = LatLngBoundsLiteral | MigrationLatLngBounds;
+
 // Migration version of google.maps.LatLng
 export class MigrationLatLng {
   #lat: number;
@@ -282,6 +284,16 @@ export enum DirectionsStatus {
   ZERO_RESULTS = "ZERO_RESULTS",
   MAX_WAYPOINTS_EXCEEDED = "MAX_WAYPOINTS_EXCEEDED",
   NOT_FOUND = "NOT_FOUND",
+}
+
+export enum GeocoderStatus {
+  ERROR = "ERROR",
+  INVALID_REQUEST = "INVALID_REQUEST",
+  OK = "OK",
+  OVER_QUERY_LIMIT = "OVER_QUERY_LIMIT",
+  REQUEST_DENIED = "REQUEST_DENIED",
+  UNKNOWN_ERROR = "UNKNOWN_ERROR",
+  ZERO_RESULTS = "ZERO_RESULTS",
 }
 
 // Migration version of google.maps.ControlPosition

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,10 @@ import {
   DistanceMatrixElementStatus,
   DistanceMatrixStatus,
 } from "./directions";
+import { MigrationGeocoder } from "./geocoder";
 import {
   DirectionsStatus,
+  GeocoderStatus,
   MigrationControlPosition,
   MigrationLatLng,
   MigrationLatLngBounds,
@@ -97,6 +99,8 @@ const migrationInit = async function () {
   MigrationAutocomplete.prototype._placeIndexName = placeIndexName;
   MigrationAutocompleteService.prototype._client = client;
   MigrationAutocompleteService.prototype._placeIndexName = placeIndexName;
+  MigrationGeocoder.prototype._client = client;
+  MigrationGeocoder.prototype._placeIndexName = placeIndexName;
   MigrationPlace._client = client;
   MigrationPlace._placeIndexName = placeIndexName;
   MigrationPlacesService.prototype._client = client;
@@ -110,10 +114,14 @@ const migrationInit = async function () {
 
   // Additionally, we need to create a places service for our directions service and distance matrix
   // service to use, since it can optionally be passed source/destinations that are string queries
-  // instead of actual LatLng coordinates. Constructing it here and passing it in will make sure
+  // instead of actual LatLng coordinates.
+  // We also need to create a places service for the Geocoder, which will use it for the
+  // address and placeId geocode requests.
+  // Constructing it here and passing it in will make sure
   // it is already configured with the appropriate client and place index name.
   MigrationDirectionsService.prototype._placesService = new MigrationPlacesService();
   MigrationDistanceMatrixService.prototype._placesService = new MigrationPlacesService();
+  MigrationGeocoder.prototype._placesService = new MigrationPlacesService();
 
   // Create the Google Maps namespace with our migration classes
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
@@ -138,6 +146,9 @@ const migrationInit = async function () {
       UnitSystem: UnitSystem,
       DistanceMatrixElementStatus: DistanceMatrixElementStatus,
       DistanceMatrixStatus: DistanceMatrixStatus,
+
+      Geocoder: MigrationGeocoder,
+      GeocoderStatus: GeocoderStatus,
 
       places: {
         Autocomplete: MigrationAutocomplete,
@@ -168,6 +179,13 @@ const migrationInit = async function () {
                   addListenerOnce: addListenerOnce,
                   removeListener: removeListener,
                 },
+              });
+              break;
+
+            case "geocoding":
+              resolve({
+                Geocoder: MigrationGeocoder,
+                GeocoderStatus: GeocoderStatus,
               });
               break;
 

--- a/src/places.ts
+++ b/src/places.ts
@@ -18,7 +18,9 @@ import {
 
 import {
   AddListenerResponse,
+  LatLngBoundsLike,
   LatLngBoundsLiteral,
+  LatLngLike,
   LatLngLiteral,
   LatLngToLngLat,
   MigrationLatLng,
@@ -40,6 +42,13 @@ interface PlaceOptions {
   id: string;
   requestedLanguage?: string | null;
   requestedRegion?: string | null;
+}
+
+interface FindPlaceFromQueryRequest {
+  fields: string[];
+  language?: string | null;
+  locationBias?: LatLngLike | LatLngBoundsLike | string;
+  query: string;
 }
 
 interface FetchFieldsRequest {
@@ -186,7 +195,7 @@ class MigrationPlacesService {
   _client: LocationClient; // This will be populated by the top level module that creates our location client
   _placeIndexName: string; // This will be populated by the top level module that is passed our place index name
 
-  findPlaceFromQuery(request, callback) {
+  findPlaceFromQuery(request: FindPlaceFromQueryRequest, callback) {
     const query = request.query;
     const fields = request.fields;
     const locationBias = request.locationBias; // optional
@@ -858,4 +867,6 @@ export {
   MigrationPlace,
   MigrationPlacesService,
   MigrationSearchBox,
+  convertAmazonPlaceToGoogle,
+  FindPlaceFromQueryRequest,
 };

--- a/test/geocoder.test.ts
+++ b/test/geocoder.test.ts
@@ -1,0 +1,458 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MigrationPlacesService } from "../src/places";
+import { GeocoderRequest, MigrationGeocoder } from "../src/geocoder";
+import { GeocoderStatus, MigrationLatLngBounds } from "../src/googleCommon";
+
+// Spy on console.error so we can verify it gets called in error cases
+jest.spyOn(console, "error").mockImplementation(() => {});
+
+// Austin, TX :)
+const testPlaceLabel = "Austin, TX, USA";
+const testLat = 30.268193;
+const testLng = -97.7457518;
+
+const testPlaceWithAddressLabel = "1337 Cool Place Road, Austin, TX, USA";
+
+const clientErrorQuery = "THIS_WILL_CAUSE_A_CLIENT_ERROR";
+
+const mockedClientSend = jest.fn((command) => {
+  return new Promise((resolve, reject) => {
+    if (command instanceof SearchPlaceIndexForTextCommand) {
+      if (command.input.Text == clientErrorQuery) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        resolve({
+          Results: [
+            {
+              Place: {
+                Label: testPlaceLabel,
+                Geometry: {
+                  Point: [testLng, testLat],
+                },
+                TimeZone: {
+                  Name: "CST",
+                  Offset: -18000,
+                },
+                Categories: ["City"],
+              },
+              PlaceId: "KEEP_AUSTIN_WEIRD",
+            },
+          ],
+        });
+      }
+    } else if (command instanceof GetPlaceCommand) {
+      if (command.input.PlaceId === undefined || command.input.PlaceId === clientErrorQuery) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        resolve({
+          Place: {
+            Label: testPlaceWithAddressLabel,
+            AddressNumber: "1337",
+            Street: "Cool Place Road",
+            Geometry: {
+              Point: [testLng, testLat],
+            },
+            TimeZone: {
+              Offset: -18000,
+            },
+            Municipality: "Austin",
+            Categories: ["City"],
+          },
+        });
+      }
+    } else if (command instanceof SearchPlaceIndexForPositionCommand) {
+      if (command.input.Position && command.input.Position[0] == -1 && command.input.Position[1] == -1) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        resolve({
+          Results: [
+            {
+              Place: {
+                Label: testPlaceLabel,
+                Geometry: {
+                  Point: [testLng, testLat],
+                },
+              },
+              PlaceId: "KEEP_AUSTIN_WEIRD",
+            },
+          ],
+        });
+      }
+    } else {
+      reject();
+    }
+  });
+});
+
+jest.mock("@aws-sdk/client-location", () => ({
+  ...jest.requireActual("@aws-sdk/client-location"),
+  LocationClient: jest.fn().mockImplementation(() => {
+    return {
+      send: mockedClientSend,
+    };
+  }),
+}));
+import {
+  GetPlaceCommand,
+  LocationClient,
+  SearchPlaceIndexForPositionCommand,
+  SearchPlaceIndexForTextCommand,
+} from "@aws-sdk/client-location";
+
+const placesService = new MigrationPlacesService();
+placesService._client = new LocationClient();
+MigrationGeocoder.prototype._client = new LocationClient();
+MigrationGeocoder.prototype._placesService = placesService;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("geocoder should return result when location is specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    location: {
+      lat: testLat,
+      lng: testLng,
+    },
+  };
+
+  geocoder.geocode(request).then((response) => {
+    const results = response.results;
+
+    expect(results.length).toStrictEqual(1);
+    const firstResult = results[0];
+
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForPositionCommand));
+
+    expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+    expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    const returnedLatLng = firstResult.geometry.location;
+    expect(returnedLatLng.lat()).toStrictEqual(testLat);
+    expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("geocoder should accept language when specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    location: {
+      lat: testLat,
+      lng: testLng,
+    },
+    language: "en",
+  };
+
+  geocoder.geocode(request).then((response) => {
+    const results = response.results;
+
+    expect(results.length).toStrictEqual(1);
+    const firstResult = results[0];
+
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForPositionCommand));
+
+    const clientInput = mockedClientSend.mock.calls[0][0].input;
+
+    expect(clientInput.Language).toStrictEqual("en");
+
+    expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+    expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    const returnedLatLng = firstResult.geometry.location;
+    expect(returnedLatLng.lat()).toStrictEqual(testLat);
+    expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("geocoder with location will also invoke the callback if specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    location: {
+      lat: testLat,
+      lng: testLng,
+    },
+  };
+
+  geocoder
+    .geocode(request, (results, status) => {
+      expect(results.length).toStrictEqual(1);
+      const firstResult = results[0];
+
+      expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+      expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+      const returnedLatLng = firstResult.geometry.location;
+      expect(returnedLatLng.lat()).toStrictEqual(testLat);
+      expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+      expect(status).toStrictEqual(GeocoderStatus.OK);
+    })
+    .then((response) => {
+      const results = response.results;
+
+      expect(results.length).toStrictEqual(1);
+      const firstResult = results[0];
+
+      expect(mockedClientSend).toHaveBeenCalledTimes(1);
+      expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForPositionCommand));
+
+      expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+      expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+      const returnedLatLng = firstResult.geometry.location;
+      expect(returnedLatLng.lat()).toStrictEqual(testLat);
+      expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("geocoder with location should handle client error", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  // [-1, -1] is mocked to cause a client error
+  const request: GeocoderRequest = {
+    location: {
+      lat: -1,
+      lng: -1,
+    },
+  };
+
+  geocoder
+    .geocode(request, (results, status) => {
+      expect(results).toBeNull();
+      expect(status).toStrictEqual(GeocoderStatus.UNKNOWN_ERROR);
+    })
+    .then(() => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(GeocoderStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(1);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("geocoder should return result when placeId is specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    placeId: "KEEP_AUSTIN_WEIRD",
+  };
+
+  geocoder.geocode(request).then((response) => {
+    const results = response.results;
+
+    expect(results.length).toStrictEqual(1);
+    const firstResult = results[0];
+
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+
+    expect(firstResult.formatted_address).toStrictEqual(testPlaceWithAddressLabel);
+    expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    const returnedLatLng = firstResult.geometry.location;
+    expect(returnedLatLng.lat()).toStrictEqual(testLat);
+    expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("geocoder with placeId will also invoke the callback if specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    placeId: "KEEP_AUSTIN_WEIRD",
+  };
+
+  geocoder
+    .geocode(request, (results, status) => {
+      expect(results.length).toStrictEqual(1);
+      const firstResult = results[0];
+
+      expect(firstResult.formatted_address).toStrictEqual(testPlaceWithAddressLabel);
+      expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+      const returnedLatLng = firstResult.geometry.location;
+      expect(returnedLatLng.lat()).toStrictEqual(testLat);
+      expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+      expect(status).toStrictEqual(GeocoderStatus.OK);
+    })
+    .then((response) => {
+      const results = response.results;
+
+      expect(results.length).toStrictEqual(1);
+      const firstResult = results[0];
+
+      expect(mockedClientSend).toHaveBeenCalledTimes(1);
+      expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+
+      expect(firstResult.formatted_address).toStrictEqual(testPlaceWithAddressLabel);
+      expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+      const returnedLatLng = firstResult.geometry.location;
+      expect(returnedLatLng.lat()).toStrictEqual(testLat);
+      expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("geocoder with placeId should handle client error", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    placeId: clientErrorQuery,
+  };
+
+  geocoder
+    .geocode(request, (results, status) => {
+      expect(results).toBeNull();
+      expect(status).toStrictEqual(GeocoderStatus.UNKNOWN_ERROR);
+    })
+    .then(() => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(GeocoderStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(1);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("geocoder should return result when address is specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    address: testPlaceLabel,
+  };
+
+  geocoder.geocode(request).then((response) => {
+    const results = response.results;
+
+    expect(results.length).toStrictEqual(1);
+    const firstResult = results[0];
+
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
+
+    expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+    expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    const returnedLatLng = firstResult.geometry.location;
+    expect(returnedLatLng.lat()).toStrictEqual(testLat);
+    expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("geocoder with address will also invoke the callback if specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    address: testPlaceLabel,
+  };
+
+  geocoder
+    .geocode(request, (results, status) => {
+      expect(results.length).toStrictEqual(1);
+      const firstResult = results[0];
+
+      expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+      expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+      const returnedLatLng = firstResult.geometry.location;
+      expect(returnedLatLng.lat()).toStrictEqual(testLat);
+      expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+      expect(status).toStrictEqual(GeocoderStatus.OK);
+    })
+    .then((response) => {
+      const results = response.results;
+
+      expect(results.length).toStrictEqual(1);
+      const firstResult = results[0];
+
+      expect(mockedClientSend).toHaveBeenCalledTimes(1);
+      expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
+
+      expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+      expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+      const returnedLatLng = firstResult.geometry.location;
+      expect(returnedLatLng.lat()).toStrictEqual(testLat);
+      expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+      // Signal the unit test is complete
+      done();
+    });
+});
+
+test("geocoder with address should accept bounds when specified", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    address: testPlaceLabel,
+    bounds: new MigrationLatLngBounds({ east: 0, north: 0, south: 4, west: 4 }),
+  };
+
+  geocoder.geocode(request).then((response) => {
+    const results = response.results;
+
+    expect(results.length).toStrictEqual(1);
+    const firstResult = results[0];
+
+    expect(mockedClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchPlaceIndexForTextCommand));
+
+    const clientInput = mockedClientSend.mock.calls[0][0].input;
+
+    expect(clientInput.BiasPosition).toStrictEqual([2, 2]);
+
+    expect(firstResult.formatted_address).toStrictEqual(testPlaceLabel);
+    expect(firstResult.place_id).toStrictEqual("KEEP_AUSTIN_WEIRD");
+    const returnedLatLng = firstResult.geometry.location;
+    expect(returnedLatLng.lat()).toStrictEqual(testLat);
+    expect(returnedLatLng.lng()).toStrictEqual(testLng);
+
+    // Signal the unit test is complete
+    done();
+  });
+});
+
+test("geocoder with address should handle client error", (done) => {
+  const geocoder = new MigrationGeocoder();
+
+  const request: GeocoderRequest = {
+    address: clientErrorQuery,
+  };
+
+  geocoder
+    .geocode(request, (results, status) => {
+      expect(results).toBeNull();
+      expect(status).toStrictEqual(GeocoderStatus.UNKNOWN_ERROR);
+    })
+    .then(() => {})
+    .catch((error) => {
+      expect(error.status).toStrictEqual(GeocoderStatus.UNKNOWN_ERROR);
+      expect(console.error).toHaveBeenCalledTimes(1);
+
+      // Signal the unit test is complete
+      done();
+    });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,6 +61,10 @@ test("importing the adapter should populate google.maps namespace for direct loa
   expect(google.maps.places).toHaveProperty("PlacesServiceStatus");
   expect(google.maps.places).toHaveProperty("SearchBox");
 
+  // Geocoder classes
+  expect(google.maps).toHaveProperty("Geocoder");
+  expect(google.maps).toHaveProperty("GeocoderStatus");
+
   // Verify our mock callback has been invoked after loading the adapter
   expect(mockMigrationCallback).toHaveBeenCalledTimes(1);
 });
@@ -135,6 +139,16 @@ test("can dynamically import marker classes", async () => {
 
   expect(AdvancedMarkerElement).toBeDefined();
   expect(Marker).toBeDefined();
+});
+
+test("can dynamically import geocoder classes", async () => {
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const google = (window as any).google;
+
+  const { Geocoder, GeocoderStatus } = await google.maps.importLibrary("geocoding");
+
+  expect(Geocoder).toBeDefined();
+  expect(GeocoderStatus).toBeDefined();
 });
 
 test("should report an error if a library we don't support is requested", async () => {


### PR DESCRIPTION
## Description
Implemented the `Geocoder` class.
* Can take either an `address`, `placeId`, or `location` input
* Updated advanced example to populate origin/destination fields with map clicks, and use the geocoder to retrieve the address of the clicked location

## Testing
Added unit tests for new geocoder module with 100% coverage.

```
------------------|---------|----------|---------|---------|-------------------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|-------------------------------
All files         |   98.94 |    93.91 |    99.1 |   98.93 |
 directions.ts    |     100 |    93.67 |     100 |     100 | 871-872,895,909-941
 events.ts        |     100 |    94.59 |     100 |     100 | 22
 geocoder.ts      |     100 |      100 |     100 |     100 |
 google.maps.d.ts |       0 |        0 |       0 |       0 |
 googleCommon.ts  |     100 |      100 |     100 |     100 |
 index.ts         |     100 |      100 |     100 |     100 |
 infoWindow.ts    |     100 |    95.83 |     100 |     100 | 118
 maps.ts          |   99.06 |    97.29 |   95.83 |   99.06 | 70
 markers.ts       |   92.07 |    81.63 |      95 |   92.07 | 89-94,117-119,166,367,370,373
 places.ts        |     100 |    96.64 |     100 |     100 | 412,669-677,808
 version.ts       |     100 |      100 |     100 |     100 |
------------------|---------|----------|---------|---------|-------------------------------

Test Suites: 9 passed, 9 total
Tests:       248 passed, 248 total
Snapshots:   0 total
Time:        5.222 s
```

Also tested updated advanced example and verified new functionality works as expected.