### PR TITLE
Fixed imports in the examples

### DIFF
--- a/examples/advanced/google.template.html
+++ b/examples/advanced/google.template.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="./advanced.css" />
 
     <!-- jQuery imports for example -->
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
 

--- a/examples/advanced/index.template.html
+++ b/examples/advanced/index.template.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="./advanced.css" />
 
     <!-- jQuery imports for example -->
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
 

--- a/examples/autoComplete/google.template.html
+++ b/examples/autoComplete/google.template.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
 
     <!-- jQuery imports for example -->
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
 

--- a/examples/autoComplete/index.template.html
+++ b/examples/autoComplete/index.template.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
 
     <!-- jQuery imports for example -->
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
 

--- a/examples/newPlaces/google.template.html
+++ b/examples/newPlaces/google.template.html
@@ -3,11 +3,6 @@
     <title>New Places Example - Google</title>
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
 
-    <!-- jQuery imports for example -->
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
-    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
-    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-
     <!-- Client logic example -->
     <script type="module" src="./example.js"></script>
   </head>

--- a/examples/newPlaces/index.template.html
+++ b/examples/newPlaces/index.template.html
@@ -3,11 +3,6 @@
     <title>New Places Example - Migration Adapter</title>
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
 
-    <!-- jQuery imports for example -->
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
-    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
-    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-
     <!-- Client logic example -->
     <script type="module" src="./example.js"></script>
   </head>


### PR DESCRIPTION
## Description
Fixed some minor import issues in the examples:
* Corrected `jquery-ui.css` import to be full path
* Removed the jquery imports from the `newPlaces` example because they aren't used

## Testing
Ran `npm run hostExamples` and verified the examples work as expected. Also verified that the `autoComplete` and `advanced` examples can now be run even without hosting on a local webserver.