### PR TITLE
Updated build action to use a node version matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: ["18.x", "20.x", "22.x"]
+
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "./package-lock.json"
       - name: Install dependencies
         run: npm ci
       - name: Lint


### PR DESCRIPTION
## Description
Updated the build action to build across a matrix of the currently supported `node` versions. Also updated to use the lock file as a dependency cache.

## Testing
Built/ran unit tests.