### PR TITLE
Added basic circle drawing support

### DIFF
--- a/documentation/circle.md
+++ b/documentation/circle.md
@@ -2,19 +2,38 @@
 
 ### [Circle class](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle)
 
-| [Methods](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle-Methods)           | Supported          | Notes                                  |
-| ----------------------------------------------------------------------------------------------------------------- | ------------------ | -------------------------------------- |
-| [getBounds](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getBounds)       | :white_check_mark: |                                        |
-| [getCenter](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getCenter)       | :white_check_mark: |                                        |
-| [getDraggable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getDraggable) | :white_check_mark: |                                        |
-| [getEditable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getEditable)   | :white_check_mark: |                                        |
-| [getMap](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getMap)             | :white_check_mark: |                                        |
-| [getRadius](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getRadius)       | :white_check_mark: |                                        |
-| [getVisible](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getVisible)     | :white_check_mark: |                                        |
-| [setCenter](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setCenter)       | :white_check_mark: |                                        |
-| [setDraggable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setDraggable) | :white_check_mark: |                                        |
-| [setEditable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setEditable)   | :white_check_mark: |                                        |
-| [setMap](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setMap)             | :x:                | Rendering circle on map not supported. |
-| [setOptions](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setOptions)     | :white_check_mark: |                                        |
-| [setRadius](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setRadius)       | :white_check_mark: |                                        |
-| [setVisible](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setVisible)     | :white_check_mark: |                                        |
+| [Methods](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle-Methods)           | Supported          | Notes |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| [getBounds](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getBounds)       | :white_check_mark: |       |
+| [getCenter](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getCenter)       | :white_check_mark: |       |
+| [getDraggable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getDraggable) | :white_check_mark: |       |
+| [getEditable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getEditable)   | :white_check_mark: |       |
+| [getMap](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getMap)             | :white_check_mark: |       |
+| [getRadius](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getRadius)       | :white_check_mark: |       |
+| [getVisible](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getVisible)     | :white_check_mark: |       |
+| [setCenter](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setCenter)       | :white_check_mark: |       |
+| [setDraggable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setDraggable) | :white_check_mark: |       |
+| [setEditable](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setEditable)   | :white_check_mark: |       |
+| [setMap](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setMap)             | :white_check_mark: |       |
+| [setOptions](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setOptions)     | :white_check_mark: |       |
+| [setRadius](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setRadius)       | :white_check_mark: |       |
+| [setVisible](https://developers.google.com/maps/documentation/javascript/reference/polygon#Circle.setVisible)     | :white_check_mark: |       |
+
+### [CircleOptions interface](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions)
+
+| [Properties](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions-Properties)         | Supported          | Notes |
+| ---------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| [center](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.center)                 | :white_check_mark: |       |
+| [clickable](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.clickable)           | :white_check_mark: |       |
+| [draggable](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.draggable)           | :white_check_mark: |       |
+| [editable](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.editable)             | :white_check_mark: |       |
+| [fillColor](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.fillColor)           | :white_check_mark: |       |
+| [fillOpacity](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.fillOpacity)       | :white_check_mark: |       |
+| [map](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.map)                       | :white_check_mark: |       |
+| [radius](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.radius)                 | :white_check_mark: |       |
+| [strokeColor](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.strokeColor)       | :white_check_mark: |       |
+| [strokeOpacity](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.strokeOpacity)   | :white_check_mark: |       |
+| [strokePosition](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.strokePosition) | :x:                |       |
+| [strokeWeight](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.strokeWeight)     | :white_check_mark: |       |
+| [visible](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.visible)               | :white_check_mark: |       |
+| [zIndex](https://developers.google.com/maps/documentation/javascript/reference/polygon#CircleOptions.zIndex)                 | :x:                |       |

--- a/documentation/maps.md
+++ b/documentation/maps.md
@@ -41,7 +41,7 @@
 | [Events](https://developers.google.com/maps/documentation/javascript/reference/map#Map-Events)                                                   | Supported          | Notes |
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ----- |
 | [bounds_changed](https://developers.google.com/maps/documentation/javascript/reference/map#Map.bounds_changed)                                   | :x:                |       |
-| [center_changed](https://developers.google.com/maps/documentation/javascript/reference/map#Map.center_changed)                                   | :x:                |       |
+| [center_changed](https://developers.google.com/maps/documentation/javascript/reference/map#Map.center_changed)                                   | :white_check_mark: |       |
 | [click](https://developers.google.com/maps/documentation/javascript/reference/map#Map.click)                                                     | :white_check_mark: |       |
 | [contextmenu](https://developers.google.com/maps/documentation/javascript/reference/map#Map.contextmenu)                                         | :white_check_mark: |       |
 | [dblclick](https://developers.google.com/maps/documentation/javascript/reference/map#Map.dblclick)                                               | :white_check_mark: |       |

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       ".(js|ts)": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx|json)$",
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx|cjs|json)$",
       "package.json"
     ],
     "coverageReporters": [

--- a/src/common/circle.ts
+++ b/src/common/circle.ts
@@ -1,0 +1,280 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as turf from "@turf/turf";
+
+import { MigrationLatLng, MigrationLatLngBounds, MigrationMVCObject } from "./googleCommon";
+import { MigrationMap } from "../maps";
+import { GeoJSONSource } from "maplibre-gl";
+
+export class MigrationCircle extends MigrationMVCObject implements google.maps.Circle {
+  center: MigrationLatLng;
+  radius: number;
+  map: google.maps.Map;
+  draggable = false;
+  editable = false;
+  fillColor = "black";
+  fillOpacity = 0.25;
+  strokeColor = "black";
+  strokeOpacity = 1.0;
+  strokeWeight = 3.0;
+  visible = true;
+
+  #sourceId: string;
+  #fillLayerId: string;
+  #lineLayerId: string;
+
+  // Keep a static layer index so we can create unique layer IDs
+  // when drawing the circle (if applicable)
+  private static layerIndex = 0;
+
+  constructor(
+    circleOrCircleOptions?: google.maps.Circle | null | google.maps.CircleLiteral | google.maps.CircleOptions,
+  ) {
+    super();
+
+    if (circleOrCircleOptions instanceof MigrationCircle) {
+      this.setCenter(circleOrCircleOptions.getCenter());
+      this.radius = circleOrCircleOptions.getRadius();
+    } else if (circleOrCircleOptions) {
+      // google.maps.CircleLiteral | google.maps.CircleOptions
+      this.setOptions(circleOrCircleOptions as google.maps.CircleOptions);
+    }
+  }
+
+  getBounds(): google.maps.LatLngBounds | null {
+    if (!this.center || !this.radius) {
+      return null;
+    }
+
+    // Google's radius is stored in meters, but turf.circle expects kilometers
+    const radiusInKm = this.radius / 1000;
+
+    const centerArray = [this.center.lng(), this.center.lat()];
+    const circle = turf.circle(centerArray, radiusInKm);
+    const bbox = turf.bbox(circle);
+
+    return new MigrationLatLngBounds({
+      west: bbox[0],
+      south: bbox[1],
+      east: bbox[2],
+      north: bbox[3],
+    });
+  }
+
+  getCenter(): google.maps.LatLng | null {
+    return this.center;
+  }
+
+  getDraggable(): boolean {
+    return this.draggable;
+  }
+
+  getEditable(): boolean {
+    return this.editable;
+  }
+
+  getMap(): google.maps.Map | null {
+    return this.map;
+  }
+
+  getRadius(): number {
+    return this.radius;
+  }
+
+  getVisible(): boolean {
+    return this.visible;
+  }
+
+  setCenter(center: google.maps.LatLng | null | google.maps.LatLngLiteral): void {
+    this.center = new MigrationLatLng(center);
+
+    this.#drawCircle();
+  }
+
+  setDraggable(draggable: boolean): void {
+    this.draggable = draggable;
+  }
+
+  setEditable(editable: boolean): void {
+    this.editable = editable;
+  }
+
+  setMap(map: google.maps.Map | null): void {
+    // If we had a valid map and are now setting to null,
+    // remove our source and layers from the previous map
+    if (this.map && map == null) {
+      const migrationMap = this.map as unknown as MigrationMap;
+      const maplibreMap = migrationMap._getMap();
+
+      if (maplibreMap.getLayer(this.#fillLayerId)) {
+        maplibreMap.removeLayer(this.#fillLayerId);
+      }
+      if (maplibreMap.getLayer(this.#lineLayerId)) {
+        maplibreMap.removeLayer(this.#lineLayerId);
+      }
+      if (maplibreMap.getSource(this.#sourceId)) {
+        maplibreMap.removeSource(this.#sourceId);
+      }
+
+      this.#fillLayerId = "";
+      this.#lineLayerId = "";
+      this.#sourceId = "";
+    }
+
+    this.map = map;
+
+    this.#drawCircle();
+  }
+
+  setOptions(options: google.maps.CircleOptions | null): void {
+    if (options == null) {
+      return;
+    }
+
+    if (options?.center != null) {
+      this.setCenter(options.center);
+    }
+
+    if (options?.draggable != null) {
+      this.setDraggable(options.draggable);
+    }
+
+    if (options?.editable != null) {
+      this.setEditable(options.editable);
+    }
+
+    if (options?.fillColor != null) {
+      this.fillColor = options.fillColor;
+    }
+
+    if (options?.fillOpacity != null) {
+      this.fillOpacity = options.fillOpacity;
+    }
+
+    if (options?.radius != null) {
+      this.setRadius(options.radius);
+    }
+
+    if (options?.strokeColor != null) {
+      this.strokeColor = options.strokeColor;
+    }
+
+    if (options?.strokeOpacity != null) {
+      this.strokeOpacity = options.strokeOpacity;
+    }
+
+    if (options?.strokeWeight != null) {
+      this.strokeWeight = options.strokeWeight;
+    }
+
+    if (options?.visible != null) {
+      this.setVisible(options.visible);
+    }
+
+    // Handle map option last, so if multiple options are set on Circle creation,
+    // it will only trigger the draw call once at the end.
+    if ("map" in options) {
+      this.setMap(options.map);
+    }
+  }
+
+  setRadius(radius: number): void {
+    this.radius = radius;
+
+    this.#drawCircle();
+  }
+
+  setVisible(visible: boolean): void {
+    this.visible = visible;
+
+    this.#drawCircle();
+  }
+
+  #getVisibilityProperty(): "visible" | "none" {
+    return this.visible ? "visible" : "none";
+  }
+
+  // Handle drawing the circle on the map, if one was specified
+  #drawCircle(): void {
+    if (!this.map) {
+      return;
+    }
+
+    // TODO: If we can clean up the listener logic in MigrationMap, then it can implement google.maps.Map
+    // and then we won't need to do this intermediate unknown cast
+    const migrationMap = this.map as unknown as MigrationMap;
+    const maplibreMap = migrationMap._getMap();
+
+    // If we try to add layers before the map's style has loaded, it will throw an error, so
+    // if it is still being loaded then queue our circle drawing until the map load event is fired
+    if (!maplibreMap.isStyleLoaded()) {
+      maplibreMap.on("load", () => {
+        this.#drawCircle();
+      });
+
+      return;
+    }
+
+    // Google's radius is stored in meters, but turf.circle expects kilometers
+    const radiusInKm = this.radius / 1000;
+
+    const centerArray = [this.center.lng(), this.center.lat()];
+    const circle = turf.circle(centerArray, radiusInKm);
+
+    // If we've already created the source and layers, just update them dynamically
+    // instead of re-creating them every time
+    const circleSource = maplibreMap.getSource(this.#sourceId) as GeoJSONSource;
+    if (circleSource) {
+      circleSource.setData(circle);
+
+      maplibreMap.setLayoutProperty(this.#fillLayerId, "visibility", this.#getVisibilityProperty());
+      maplibreMap.setLayoutProperty(this.#lineLayerId, "visibility", this.#getVisibilityProperty());
+
+      return;
+    }
+
+    // Setup our source and layer ids with a unique suffix
+    this.#sourceId = "circle-source-" + MigrationCircle.layerIndex;
+    this.#fillLayerId = "circle-fill-" + MigrationCircle.layerIndex;
+    this.#lineLayerId = "circle-line-" + MigrationCircle.layerIndex;
+
+    // Add the circle data as a GeoJSON source
+    maplibreMap.addSource(this.#sourceId, {
+      type: "geojson",
+      data: circle,
+    });
+
+    // Add the circle fill layer
+    maplibreMap.addLayer({
+      id: this.#fillLayerId,
+      type: "fill",
+      source: this.#sourceId,
+      layout: {
+        visibility: this.#getVisibilityProperty(),
+      },
+      paint: {
+        "fill-color": this.fillColor,
+        "fill-opacity": this.fillOpacity,
+      },
+    });
+
+    // Add the circle line layer
+    maplibreMap.addLayer({
+      id: this.#lineLayerId,
+      type: "line",
+      source: this.#sourceId,
+      layout: {
+        visibility: this.#getVisibilityProperty(),
+      },
+      paint: {
+        "line-color": this.strokeColor,
+        "line-opacity": this.strokeOpacity,
+        "line-width": this.strokeWeight,
+      },
+    });
+
+    // Increment our static layer index to keep them unique
+    MigrationCircle.layerIndex++;
+  }
+}

--- a/src/common/googleCommon.ts
+++ b/src/common/googleCommon.ts
@@ -312,107 +312,6 @@ export class MigrationMVCObject implements google.maps.MVCObject {
   }
 }
 
-export class MigrationCircle extends MigrationMVCObject implements google.maps.Circle {
-  center: MigrationLatLng;
-  radius: number;
-  map: google.maps.Map;
-  draggable = false;
-  editable = false;
-  visible = true;
-
-  constructor(
-    circleOrCircleOptions?: google.maps.Circle | null | google.maps.CircleLiteral | google.maps.CircleOptions,
-  ) {
-    super();
-
-    if (circleOrCircleOptions instanceof MigrationCircle) {
-      this.setCenter(circleOrCircleOptions.getCenter());
-      this.radius = circleOrCircleOptions.getRadius();
-    } else if (circleOrCircleOptions) {
-      // google.maps.CircleLiteral | google.maps.CircleOptions
-      this.setOptions(circleOrCircleOptions as google.maps.CircleOptions);
-    }
-  }
-
-  getBounds(): google.maps.LatLngBounds | null {
-    if (!this.center || !this.radius) {
-      return null;
-    }
-
-    // Google's radius is stored in meters, but turf.circle expects kilometers
-    const radiusInKm = this.radius / 1000;
-
-    const centerArray = [this.center.lng(), this.center.lat()];
-    const circle = turf.circle(centerArray, radiusInKm);
-    const bbox = turf.bbox(circle);
-
-    return new MigrationLatLngBounds({
-      west: bbox[0],
-      south: bbox[1],
-      east: bbox[2],
-      north: bbox[3],
-    });
-  }
-
-  getCenter(): google.maps.LatLng | null {
-    return this.center;
-  }
-
-  getDraggable(): boolean {
-    return this.draggable;
-  }
-
-  getEditable(): boolean {
-    return this.editable;
-  }
-
-  getMap(): google.maps.Map | null {
-    return this.map;
-  }
-
-  getRadius(): number {
-    return this.radius;
-  }
-
-  getVisible(): boolean {
-    return this.visible;
-  }
-
-  setCenter(center: google.maps.LatLng | null | google.maps.LatLngLiteral): void {
-    this.center = new MigrationLatLng(center);
-  }
-
-  setDraggable(draggable: boolean): void {
-    this.draggable = draggable;
-  }
-
-  setEditable(editable: boolean): void {
-    this.editable = editable;
-  }
-
-  setMap(map: google.maps.Map | null): void {
-    this.map = map;
-  }
-
-  setOptions(options: google.maps.CircleOptions | null): void {
-    if (options?.center) {
-      this.setCenter(options.center);
-    }
-
-    if (options?.radius) {
-      this.setRadius(options.radius);
-    }
-  }
-
-  setRadius(radius: number): void {
-    this.radius = radius;
-  }
-
-  setVisible(visible: boolean): void {
-    this.visible = visible;
-  }
-}
-
 // function that takes in a Google LatLng or LatLngLiteral and returns array containing a
 // longitude and latitude (valid MapLibre input), returns 'null' if 'coord' parameter
 // is not a Google LatLng or LatLngLiteral
@@ -530,6 +429,7 @@ export interface AddListenerResponse {
 
 // Migration version of Google's Events
 export const MigrationEvent = {
+  center_changed: "center_changed",
   click: "click",
   dblclick: "dblclick",
   contextmenu: "contextmenu",
@@ -549,6 +449,7 @@ export const MigrationEvent = {
 // Constant responsible for translating Google Event names to corresponding MapLibre Event names,
 // these Event names are passed into MapLibre's 'on' method
 export const GoogleToMaplibreEvent = {};
+GoogleToMaplibreEvent[MigrationEvent.center_changed] = "move";
 GoogleToMaplibreEvent[MigrationEvent.click] = "click";
 GoogleToMaplibreEvent[MigrationEvent.dblclick] = "dblclick";
 GoogleToMaplibreEvent[MigrationEvent.contextmenu] = "contextmenu";
@@ -576,6 +477,7 @@ export const GoogleMapMouseEvent = [
 
 // List of Google Map Events that do not have any parameters
 export const GoogleMapEvent = [
+  MigrationEvent.center_changed,
   MigrationEvent.tilesloaded,
   MigrationEvent.tilt_changed,
   MigrationEvent.zoom_changed,

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from "./circle";
+export * from "./googleCommon";

--- a/src/directions.ts
+++ b/src/directions.ts
@@ -16,7 +16,7 @@ import {
   MigrationLatLng,
   MigrationLatLngBounds,
   PlacesServiceStatus,
-} from "./googleCommon";
+} from "./common";
 import { MigrationMap } from "./maps";
 import { MigrationMarker } from "./markers";
 import { MigrationPlacesService } from "./places";

--- a/src/events.ts
+++ b/src/events.ts
@@ -10,7 +10,7 @@ import {
   MigrationEvent,
   GoogleMarkerMouseDOMEvent,
   GoogleMarkerMouseEvent,
-} from "./googleCommon";
+} from "./common";
 import { MigrationMap } from "./maps";
 import { MigrationMarker } from "./markers";
 import { MigrationInfoWindow } from "./infoWindow";

--- a/src/geocoder.ts
+++ b/src/geocoder.ts
@@ -15,7 +15,7 @@ import {
   MigrationLatLng,
   PlacesServiceStatus,
   MigrationLatLngBounds,
-} from "./googleCommon";
+} from "./common";
 import { convertAmazonPlaceToGoogleV1, MigrationPlacesService } from "./places";
 
 interface GeocoderRequest {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
   MigrationLatLngBounds,
   MigrationMVCObject,
   PlacesServiceStatus,
-} from "./googleCommon";
+} from "./common";
 import { MigrationMap } from "./maps";
 import { MigrationMarker } from "./markers";
 import {

--- a/src/infoWindow.ts
+++ b/src/infoWindow.ts
@@ -3,14 +3,14 @@
 
 import { Popup, PopupOptions } from "maplibre-gl";
 import {
+  AddListenerResponse,
   GoogleInfoWindowEvent,
   GoogleToMaplibreEvent,
   LatLngToLngLat,
   MigrationEvent,
   MigrationLatLng,
-} from "./googleCommon";
+} from "./common";
 import { addListenerOnce } from "./events";
-import { AddListenerResponse } from "./googleCommon";
 
 const focusQuerySelector = [
   "a[href]",

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -13,7 +13,7 @@ import {
   MapTypeId,
   MigrationLatLng,
   MigrationLatLngBounds,
-} from "./googleCommon";
+} from "./common";
 import { PACKAGE_VERSION } from "./version";
 
 const systemIsDarkMode = () => {

--- a/src/markers.ts
+++ b/src/markers.ts
@@ -10,7 +10,7 @@ import {
   LatLngToLngLat,
   MigrationEvent,
   MigrationLatLng,
-} from "./googleCommon";
+} from "./common";
 
 class MigrationMarker {
   #marker: Marker;

--- a/src/places.ts
+++ b/src/places.ts
@@ -42,7 +42,7 @@ import {
   MigrationLatLng,
   MigrationLatLngBounds,
   PlacesServiceStatus,
-} from "./googleCommon";
+} from "./common";
 
 interface AutocompletePrediction {
   description: string;

--- a/test/directions.test.ts
+++ b/test/directions.test.ts
@@ -12,7 +12,7 @@ import {
   DistanceMatrixStatus,
 } from "../src/directions";
 import { MigrationPlacesService } from "../src/places";
-import { DirectionsStatus, MigrationLatLng, MigrationLatLngBounds } from "../src/googleCommon";
+import { DirectionsStatus, MigrationLatLng, MigrationLatLngBounds } from "../src/common";
 
 const mockAddControl = jest.fn();
 const mockFitBounds = jest.fn();

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -5,7 +5,7 @@ import { MigrationMap } from "../src/maps";
 import { MigrationMarker } from "../src/markers";
 import { MigrationInfoWindow } from "../src/infoWindow";
 import { MigrationDirectionsRenderer } from "../src/directions";
-import { MigrationLatLng } from "../src/googleCommon";
+import { MigrationLatLng } from "../src/common";
 import { MigrationSearchBox, MigrationAutocomplete } from "../src/places";
 import { addListener, addListenerOnce, removeListener } from "../src/events";
 
@@ -180,6 +180,42 @@ test("should call handler after tilesloaded when addListener", () => {
   addListener(migrationMap, "tilesloaded", handlerSpy);
 
   // Simulate mocked tilesloaded call
+  mockMap.on.mock.calls[0][1]();
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+});
+
+test("should call handler after center_changed when addListenerOnce", () => {
+  // mock map so that we can mock on so that we can mock center_changed
+  const mockMap = {
+    once: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  addListenerOnce(migrationMap, "center_changed", handlerSpy);
+
+  // Simulate mocked center_changed call
+  mockMap.once.mock.calls[0][1]();
+
+  expect(handlerSpy).toHaveBeenCalledTimes(1);
+});
+
+test("should call handler after center_changed when addListener", () => {
+  // mock map so that we can mock on so that we can mock center_changed
+  const mockMap = {
+    on: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  // add spy as handler
+  const handlerSpy = jest.fn();
+  addListener(migrationMap, "center_changed", handlerSpy);
+
+  // Simulate mocked center_changed call
   mockMap.on.mock.calls[0][1]();
 
   expect(handlerSpy).toHaveBeenCalledTimes(1);
@@ -611,6 +647,21 @@ test("should remove map tilesloaded listener", () => {
   migrationMap._setMap(mockMap);
 
   const listener = addListenerOnce(migrationMap, "tilesloaded", {});
+  removeListener(listener);
+
+  expect(mockMap.off).toHaveBeenCalledTimes(1);
+});
+
+test("should remove map center_changed listener", () => {
+  // mock map so that we can mock on so that we can mock center_changed
+  const mockMap = {
+    once: jest.fn(),
+    off: jest.fn(),
+  };
+  const migrationMap = new MigrationMap(null, {});
+  migrationMap._setMap(mockMap);
+
+  const listener = addListenerOnce(migrationMap, "center_changed", {});
   removeListener(listener);
 
   expect(mockMap.off).toHaveBeenCalledTimes(1);

--- a/test/geocoder.test.ts
+++ b/test/geocoder.test.ts
@@ -3,7 +3,7 @@
 
 import { MigrationPlacesService } from "../src/places";
 import { GeocoderRequest, MigrationGeocoder } from "../src/geocoder";
-import { GeocoderStatus, MigrationLatLngBounds } from "../src/googleCommon";
+import { GeocoderStatus, MigrationLatLngBounds } from "../src/common";
 
 // Spy on console.error so we can verify it gets called in error cases
 jest.spyOn(console, "error").mockImplementation(() => {});

--- a/test/infoWindow.test.ts
+++ b/test/infoWindow.test.ts
@@ -4,7 +4,7 @@
 import { MigrationMap } from "../src/maps";
 import { MigrationMarker } from "../src/markers";
 import { MigrationInfoWindow } from "../src/infoWindow";
-import { MigrationLatLng } from "../src/googleCommon";
+import { MigrationLatLng } from "../src/common";
 
 // Mock maplibre because it requires a valid DOM container to create a Map
 // We don't need to verify maplibre itself, we just need to verify that

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -8,7 +8,7 @@ import {
   MigrationControlPosition,
   MigrationLatLng,
   MigrationLatLngBounds,
-} from "../src/googleCommon";
+} from "../src/common";
 
 // Mock maplibre because it requires a valid DOM container to create a Map
 // We don't need to verify maplibre itself, we just need to verify that

--- a/test/markers.test.ts
+++ b/test/markers.test.ts
@@ -3,7 +3,7 @@
 
 import { MigrationMap } from "../src/maps";
 import { MigrationMarker } from "../src/markers";
-import { MigrationLatLng } from "../src/googleCommon";
+import { MigrationLatLng } from "../src/common";
 
 // Mock maplibre because it requires a valid DOM container to create a Map
 // We don't need to verify maplibre itself, we just need to verify that

--- a/test/places.test.ts
+++ b/test/places.test.ts
@@ -12,7 +12,7 @@ import {
   MigrationSearchBox,
   PlaceOpeningHours,
 } from "../src/places";
-import { MigrationCircle, MigrationLatLng, MigrationLatLngBounds, PlacesServiceStatus } from "../src/googleCommon";
+import { MigrationCircle, MigrationLatLng, MigrationLatLngBounds, PlacesServiceStatus } from "../src/common";
 
 // Spy on console.error so we can verify it gets called in error cases
 jest.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
### Description
Added basic drawing support to the `Circle` class.

This also included some other minor changes:
* Small refactoring to move `googleCommon` into sub-module and split `Circle` into its own module (over time will split more classes into their own modules since things have grown since the initial release)
* Updated the Circle supported API docs to add `CircleOptions` and updated which fields are supported
* Added `center_changed` as supported event for maps
* Added `cjs` to jest ignore pattern to fix warning messages

### Testing
Added unit tests to cover the new functionality. Also tested locally with example that is being worked for a separate feature that will be part of a follow-up PR.

![Screenshot 2025-04-24 at 12 59 27 PM](https://github.com/user-attachments/assets/62f3f1f0-5681-483f-ac2f-db902ed30f99)