### PR TITLE
Added support for nearbySearch API

### DIFF
--- a/documentation/placesService.md
+++ b/documentation/placesService.md
@@ -2,10 +2,10 @@
 
 ### [PlacesService class](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService)
 
-| [Static Methods](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/event#event-Static-Methods)                                      | Supported          | Notes                                            |
+| [Methods](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService-Methods)                                   | Supported          | Notes                                            |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------ |
 | [findPlaceFromPhoneNumber](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.findPlaceFromPhoneNumber) | :x:                |                                                  |
 | [findPlaceFromQuery](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.findPlaceFromQuery)             | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md). |
 | [getDetails](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.getDetails)                             | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md)  |
-| [nearbySearch](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.nearbySearch)                         | :x:                |                                                  |
+| [nearbySearch](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.nearbySearch)                         | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md)  |
 | [textSearch](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.textSearch)                             | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md). |

--- a/examples/landingPage.html
+++ b/examples/landingPage.html
@@ -27,6 +27,11 @@
     </div>
 
     <div>
+      <span class="example-links"><a href="./nearbySearch/index.html" target="_blank">Nearby Search</a></span>
+      <span><a href="./nearbySearch/google.html" target="_blank">(Google)</a></span>
+    </div>
+
+    <div>
       <span class="example-links"><a href="./directions/index.html" target="_blank">Directions</a></span>
       <span><a href="./directions/google.html" target="_blank">(Google)</a></span>
     </div>

--- a/examples/nearbySearch/example.js
+++ b/examples/nearbySearch/example.js
@@ -1,0 +1,116 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This example showcases the nearbySearch API, as well as drawing a circle on a Google Map.
+// The example draws a circle on the map, for which the radius can be scaled dynamically.
+// The user can choose from different place type categories, and then perform a nearbySearch,
+// which will return any places matching the specified type within the circle radius.
+//
+// This is meant to be showcased as the client logic that is able to remain untouched
+// and retain the same functionality when using the Amazon Location Migration SDK.
+
+let map;
+let service;
+let markers = [];
+let searchCircle;
+
+function initMap() {
+  const austinCoords = new google.maps.LatLng(30.268193, -97.7457518); // Austin, TX :)
+
+  map = new google.maps.Map(document.getElementById("map"), {
+    center: austinCoords,
+    zoom: 14,
+  });
+
+  service = new google.maps.places.PlacesService(map);
+
+  // Initialize the circle
+  searchCircle = new google.maps.Circle({
+    strokeColor: "#146eb4",
+    strokeOpacity: 0.8,
+    strokeWeight: 2,
+    fillColor: "#146eb4",
+    fillOpacity: 0.15,
+    map,
+    center: austinCoords,
+    radius: 1500,
+  });
+
+  // Add radius slider listener
+  const radiusSlider = document.getElementById("radius");
+  const radiusValue = document.getElementById("radius-value");
+
+  radiusSlider.addEventListener("input", () => {
+    const radius = parseInt(radiusSlider.value);
+    radiusValue.textContent = `${radius}m`;
+    if (searchCircle) {
+      searchCircle.setRadius(radius);
+    }
+  });
+
+  // Move the circle to stay on the center of the map
+  map.addListener("center_changed", () => {
+    if (searchCircle) {
+      searchCircle.setCenter(map.getCenter());
+    }
+  });
+
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const userLocation = {
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        };
+        map.setCenter(userLocation);
+        if (searchCircle) {
+          searchCircle.setCenter(userLocation);
+        }
+      },
+      () => {
+        console.log("Error: The Geolocation service failed.");
+      },
+    );
+  }
+}
+
+function searchNearbyPlaces() {
+  // Clear any existing markers
+  markers.forEach((marker) => marker.setMap(null));
+  markers = [];
+
+  const radius = parseInt(document.getElementById("radius").value);
+  const center = map.getCenter();
+
+  const request = {
+    location: center,
+    radius: radius,
+    type: document.getElementById("place-type").value,
+  };
+
+  service.nearbySearch(request, (results, status) => {
+    if (status === google.maps.places.PlacesServiceStatus.OK && results) {
+      results.forEach((place) => {
+        if (place.geometry && place.geometry.location) {
+          const marker = new google.maps.Marker({
+            map: map,
+            position: place.geometry.location,
+            title: place.name,
+          });
+
+          markers.push(marker);
+
+          // Add click listener for info window
+          marker.addListener("click", () => {
+            const infowindow = new google.maps.InfoWindow({
+              content: `<strong>${place.name}</strong><br>
+                        Address: ${place.vicinity || "N/A"}
+                        `,
+            });
+            infowindow.open(map, marker);
+          });
+        }
+      });
+    }
+  });
+}

--- a/examples/nearbySearch/google.template.html
+++ b/examples/nearbySearch/google.template.html
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <title>Basic Map Example - Google</title>
+    <link rel="stylesheet" type="text/css" href="../common/style.css" />
+
+    <!-- Client logic example -->
+    <script type="text/javascript" src="./example.js"></script>
+  </head>
+  <body>
+    <!-- Map element -->
+    <div id="search-controls">
+      <select id="place-type">
+        <option value="restaurant">Restaurants</option>
+        <option value="cafe">Cafes</option>
+        <option value="store">Stores</option>
+        <option value="hospital">Hospitals</option>
+      </select>
+      <input type="range" id="radius" value="1500" min="100" max="5000" step="100" />
+      <span id="radius-value">1500m</span>
+      <button onclick="searchNearbyPlaces()">Search Nearby</button>
+    </div>
+    <div id="map"></div>
+
+    <!-- Google Maps API import -->
+    <script
+      async
+      defer
+      src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&callback=initMap&libraries=places"
+    ></script>
+  </body>
+</html>

--- a/examples/nearbySearch/index.template.html
+++ b/examples/nearbySearch/index.template.html
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <title>Basic Map Example - Migration SDK</title>
+    <link rel="stylesheet" type="text/css" href="../common/style.css" />
+
+    <!-- Client logic example -->
+    <script type="text/javascript" src="./example.js"></script>
+  </head>
+  <body>
+    <!-- Map element -->
+    <div id="search-controls">
+      <select id="place-type">
+        <option value="restaurant">Restaurants</option>
+        <option value="cafe">Cafes</option>
+        <option value="store">Stores</option>
+        <option value="hospital">Hospitals</option>
+      </select>
+      <input type="range" id="radius" value="1500" min="100" max="5000" step="100" />
+      <span id="radius-value">1500m</span>
+      <button onclick="searchNearbyPlaces()">Search Nearby</button>
+    </div>
+    <div id="map"></div>
+
+    <!-- Migration script import -->
+    <script
+      async
+      defer
+      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
+    ></script>
+  </body>
+</html>

--- a/src/infoWindow.ts
+++ b/src/infoWindow.ts
@@ -170,7 +170,7 @@ class MigrationInfoWindow {
 
   setContent(content?) {
     if (typeof content === "string") {
-      if (this._containsOnlyHTMLElements(content)) {
+      if (this._containsHTMLElements(content)) {
         this.#popup.setHTML(content);
       } else {
         this.#popup.setText(content);
@@ -246,16 +246,14 @@ class MigrationInfoWindow {
   }
 
   // Internal method for checking if a string contains valid HTML
-  _containsOnlyHTMLElements(str: string): boolean {
+  _containsHTMLElements(str: string): boolean {
     // Regular expression to match complete HTML elements (opening and closing tags with content)
     const htmlElementRegex = /<([a-z][a-z0-9]*)\b[^>]*>(.*?)<\/\1>/gi;
 
     // Check if the string contains any complete HTML elements
     const hasHTMLElements = str.match(htmlElementRegex) !== null;
 
-    // Check if the string contains any text outside of HTML elements
-    const textOutsideElements = str.replace(htmlElementRegex, "").trim();
-    return hasHTMLElements && textOutsideElements.length === 0;
+    return hasHTMLElements;
   }
 }
 

--- a/test/infoWindow.test.ts
+++ b/test/infoWindow.test.ts
@@ -69,6 +69,18 @@ test("should set infowindow content option with string containing HTML", () => {
   expect(Popup.prototype.setHTML).toHaveBeenCalledWith(htmlString);
 });
 
+test("should set infowindow content option with string containing HTML and other text", () => {
+  const htmlString = "<h1>Hello World!</h1>Extra Text";
+  const testInfoWindow = new MigrationInfoWindow({
+    content: htmlString,
+  });
+
+  expect(testInfoWindow).not.toBeNull();
+  expect(Popup).toHaveBeenCalledTimes(1);
+  expect(Popup.prototype.setHTML).toHaveBeenCalledTimes(1);
+  expect(Popup.prototype.setHTML).toHaveBeenCalledWith(htmlString);
+});
+
 test("should set infowindow content option with HTML elements", () => {
   const h1Element = document.createElement("h1");
   h1Element.textContent = "Hello World!";


### PR DESCRIPTION
### Description
Added support for the `nearbySearch` API, which is a new capability of our Amazon Location Service standalone Places SDK. We translate Google's `nearbySearch` API request into a `SearchNearby` request for Amazon Location Service.

Also updated supported API docs for `PlacesService` to add `nearbySearch`, as well as fixed an incorrect link to Google's places methods API docs.

Some other minor changes made were:
* Modified `InfoWindow` implementation to set content as HTML if the content string contains any HTML, not just only HTML, to match Google's implementation
* Updated `AdditionalFeatures` comments to be more explicit about which fields the feature corresponds to

### Testing
Added a new nearby search example that involves drawing a circle on the map and then performing a `nearbySearch` within that search radius. There is a slider to control the radius of the circle, and a drop-down to change which category place type to search for. Markers are placed for all of the results found.

Added unit tests to maintain 100% coverage of the new logic. Built/ran new example locally and verified it works as expected. Also tested other examples to make sure there was no regression.


https://github.com/user-attachments/assets/3fe68a3e-7aa3-48a3-8f31-ca88b7c7cd4f