### PR TITLE
Refactored to use available types instead of re-defining them

### DIFF
--- a/src/common/googleCommon.ts
+++ b/src/common/googleCommon.ts
@@ -4,9 +4,6 @@
 import { LngLatBounds } from "maplibre-gl";
 import * as turf from "@turf/turf";
 
-export type LatLngLike = google.maps.LatLngLiteral | google.maps.LatLng;
-export type LatLngBoundsLike = google.maps.LatLngBoundsLiteral | google.maps.LatLngBounds;
-
 // Migration version of google.maps.LatLng
 export class MigrationLatLng implements google.maps.LatLng {
   #lat: number;
@@ -123,7 +120,7 @@ export class MigrationLatLngBounds implements google.maps.LatLngBounds {
     } else {
       let southWest, northEast;
       if (ne) {
-        southWest = new MigrationLatLng(swOrLatLngBounds as LatLngLike);
+        southWest = new MigrationLatLng(swOrLatLngBounds as google.maps.LatLngLiteral | google.maps.LatLng);
         northEast = new MigrationLatLng(ne);
 
         west = southWest.lng();

--- a/src/geocoder.ts
+++ b/src/geocoder.ts
@@ -7,39 +7,8 @@ import {
   SearchPlaceIndexForPositionRequest,
 } from "@aws-sdk/client-location";
 
-import {
-  GeocoderStatus,
-  LatLngLike,
-  LatLngBoundsLike,
-  LatLngToLngLat,
-  MigrationLatLng,
-  PlacesServiceStatus,
-  MigrationLatLngBounds,
-} from "./common";
+import { GeocoderStatus, LatLngToLngLat, PlacesServiceStatus, MigrationLatLngBounds } from "./common";
 import { convertAmazonPlaceToGoogleV1, MigrationPlacesService } from "./places";
-
-interface GeocoderRequest {
-  address?: string | null;
-  bounds?: LatLngBoundsLike | null;
-  language?: string | null;
-  location?: LatLngLike | null;
-  placeId?: string | null;
-}
-
-interface GeocoderResponse {
-  results: GeocoderResult[];
-}
-
-interface GeocoderResult {
-  formatted_address: string;
-  geometry: GeocoderGeometry;
-  place_id: string;
-}
-
-interface GeocoderGeometry {
-  bounds?: MigrationLatLngBounds;
-  location: MigrationLatLng;
-}
 
 class MigrationGeocoder {
   _client: LocationClient; // This will be populated by the top level module that creates our location client
@@ -49,7 +18,7 @@ class MigrationGeocoder {
   // been configured with our place index name
   _placesService: MigrationPlacesService;
 
-  geocode(request: GeocoderRequest, callback?): Promise<GeocoderResponse> {
+  geocode(request: google.maps.GeocoderRequest, callback?): Promise<google.maps.GeocoderResponse> {
     const bounds = request.bounds;
     const language = request.language;
     const location = request.location;
@@ -174,4 +143,4 @@ class MigrationGeocoder {
   }
 }
 
-export { GeocoderRequest, MigrationGeocoder };
+export { MigrationGeocoder };

--- a/test/geocoder.test.ts
+++ b/test/geocoder.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MigrationPlacesService } from "../src/places";
-import { GeocoderRequest, MigrationGeocoder } from "../src/geocoder";
+import { MigrationGeocoder } from "../src/geocoder";
 import { GeocoderStatus, MigrationLatLngBounds } from "../src/common";
 
 // Spy on console.error so we can verify it gets called in error cases
@@ -251,7 +251,7 @@ afterEach(() => {
 test("geocoder should return result when location is specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     location: {
       lat: testLat,
       lng: testLng,
@@ -281,7 +281,7 @@ test("geocoder should return result when location is specified", (done) => {
 test("geocoder should accept language when specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     location: {
       lat: testLat,
       lng: testLng,
@@ -316,7 +316,7 @@ test("geocoder should accept language when specified", (done) => {
 test("geocoder with location will also invoke the callback if specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     location: {
       lat: testLat,
       lng: testLng,
@@ -360,7 +360,7 @@ test("geocoder with location should handle client error", (done) => {
   const geocoder = new MigrationGeocoder();
 
   // [-1, -1] is mocked to cause a client error
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     location: {
       lat: -1,
       lng: -1,
@@ -385,7 +385,7 @@ test("geocoder with location should handle client error", (done) => {
 test("geocoder should return result when placeId is specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     placeId: "KEEP_AUSTIN_WEIRD",
   };
 
@@ -412,7 +412,7 @@ test("geocoder should return result when placeId is specified", (done) => {
 test("geocoder with placeId will also invoke the callback if specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     placeId: "KEEP_AUSTIN_WEIRD",
   };
 
@@ -452,7 +452,7 @@ test("geocoder with placeId will also invoke the callback if specified", (done) 
 test("geocoder with placeId should handle client error", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     placeId: clientErrorQuery,
   };
 
@@ -474,7 +474,7 @@ test("geocoder with placeId should handle client error", (done) => {
 test("geocoder should return result when address is specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     address: testPlaceWithAddressLabel,
   };
 
@@ -501,7 +501,7 @@ test("geocoder should return result when address is specified", (done) => {
 test("geocoder with address will also invoke the callback if specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     address: testPlaceWithAddressLabel,
   };
 
@@ -541,7 +541,7 @@ test("geocoder with address will also invoke the callback if specified", (done) 
 test("geocoder with address should accept bounds when specified", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     address: testPlaceWithAddressLabel,
     bounds: new MigrationLatLngBounds({ east: 0, north: 0, south: 4, west: 4 }),
   };
@@ -573,7 +573,7 @@ test("geocoder with address should accept bounds when specified", (done) => {
 test("geocoder with address should handle client error", (done) => {
   const geocoder = new MigrationGeocoder();
 
-  const request: GeocoderRequest = {
+  const request: google.maps.GeocoderRequest = {
     address: clientErrorQuery,
   };
 

--- a/test/places.test.ts
+++ b/test/places.test.ts
@@ -10,7 +10,6 @@ import {
   MigrationPlace,
   MigrationPlacesService,
   MigrationSearchBox,
-  PlaceOpeningHours,
 } from "../src/places";
 import {
   convertAmazonPlaceTypeToGoogle,
@@ -811,7 +810,7 @@ test("getDetails should return all fields by default", (done) => {
     expect(addressComponents[7].types).toStrictEqual(["postal_code"]);
 
     // Opening hours
-    const openingHours: PlaceOpeningHours = result.opening_hours;
+    const openingHours: google.maps.places.PlaceOpeningHours = result.opening_hours;
     const periods = openingHours.periods;
 
     expect(periods).toBeDefined();


### PR DESCRIPTION
### Description
Refactored to use pre-defined types instead of having to explicitly declare them (with the exception of cases where we need to declare our own in order to offer backwards compatibility to Google Maps users migrating from older API versions).

### Testing
Ran unit tests. Also built/ran local examples and verified they still work as expected. 