### PR TITLE
Added support for getPlacePredictions with standalone GeoPlaces

### DIFF
--- a/src/places/autocomplete_service.ts
+++ b/src/places/autocomplete_service.ts
@@ -1,32 +1,82 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { GeoPlacesClient, SuggestAdditionalFeature, SuggestCommand, SuggestRequest } from "@aws-sdk/client-geo-places";
+import {
+  AutocompleteCommand,
+  AutocompleteRequest,
+  GeoPlacesClient,
+  SuggestAdditionalFeature,
+  SuggestCommand,
+  SuggestRequest,
+} from "@aws-sdk/client-geo-places";
 
 import { LatLngToLngLat, MigrationLatLng, MigrationLatLngBounds, PlacesServiceStatus } from "../common";
 
-// FIXME: Temporarily add QueryAutocompletePrediction as a possible type until getPlacePredictions has been
-// re-implemented using the new Autocomplete API. All of these Autocomplete/Query predicition types can be
-// removed once we complete this work.
-interface AutocompleteResponse {
-  predictions: AutocompletePrediction[] | QueryAutocompletePrediction[];
-}
-interface AutocompletePrediction {
-  description: string;
-  place_id: string;
-}
-interface QueryAutocompletePrediction {
-  description: string;
-  matched_substrings: google.maps.places.PredictionSubstring[];
-  place_id?: string;
-  reference?: string;
-  terms: google.maps.places.PredictionTerm[];
-}
+// Handle location/bounds restrictions. bounds and location have been deprecated, and in some cases
+// have actually been removed (although still mentioned in the documentation as only deprecated).
+//   * locationBias is the top preferred field, and can be MigrationLatLng|LatLngLiteral|MigrationLatLngBounds|LatLngBoundsLiteral
+//   * bounds / locationRestriction is the next preferred field
+//   * location is the final field that is checked
+//   * radius must be paired with a LatLng (locationBias / location) to specify a circle bias
+// This logic can be shared between both getQueryPredictions and getPlacePredictions
+const setRequestLocationBias = (
+  input: AutocompleteRequest | SuggestRequest,
+  location,
+  locationBias,
+  bounds,
+  radius,
+) => {
+  let inputBounds, inputLocation;
+  if (locationBias) {
+    // MigrationLatLng|LatLngLiteral
+    if (locationBias.lat !== undefined && locationBias.lng !== undefined) {
+      inputLocation = new MigrationLatLng(locationBias);
+    } /* MigrationLatLngBounds|LatLngBoundsLiteral */ else {
+      inputBounds = new MigrationLatLngBounds(locationBias);
+    }
+  } else if (bounds) {
+    inputBounds = new MigrationLatLngBounds(bounds);
+  } else if (location) {
+    inputLocation = new MigrationLatLng(location);
+  }
 
+  // If bounds was found, then location is ignored
+  if (inputBounds) {
+    const southWest = inputBounds.getSouthWest();
+    const northEast = inputBounds.getNorthEast();
+
+    input.Filter = {
+      BoundingBox: [southWest.lng(), southWest.lat(), northEast.lng(), northEast.lat()],
+    };
+  } else if (inputLocation) {
+    // If we have a location and a radius, then we will use a circle
+    // Otherwise, just the location will be used
+    const lngLat = LatLngToLngLat(inputLocation);
+    if (lngLat) {
+      if (radius) {
+        input.Filter = {
+          Circle: {
+            Center: lngLat,
+            Radius: radius,
+          },
+        };
+      } else {
+        input.BiasPosition = lngLat;
+      }
+    }
+  }
+};
+
+// Migration class for google.maps.places.AutocompleteService
+// https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService
 export class MigrationAutocompleteService {
   _client: GeoPlacesClient; // This will be populated by the top level module that creates our location client
 
-  getQueryPredictions(request, callback: (a: QueryAutocompletePrediction[], b: PlacesServiceStatus) => void) {
+  // https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService.getQueryPredictions
+  getQueryPredictions(
+    request,
+    callback: (a: google.maps.places.QueryAutocompletePrediction[], b: PlacesServiceStatus) => void,
+  ) {
     const query = request.input;
     const location = request.location; // optional
     const locationBias = request.locationBias; // optional
@@ -40,51 +90,8 @@ export class MigrationAutocompleteService {
       AdditionalFeatures: [SuggestAdditionalFeature.CORE], // Without this, only the ID and Title will be returned
     };
 
-    // Handle location/bounds restrictions. bounds and location have been deprecated, and in some cases
-    // have actually been removed (although still mentioned in the documentation as only deprecated).
-    //   * locationBias is the top preferred field, and can be MigrationLatLng|LatLngLiteral|MigrationLatLngBounds|LatLngBoundsLiteral
-    //   * bounds / locationRestriction is the next preferred field
-    //   * location is the final field that is checked
-    //   * radius must be paired with a LatLng (locationBias / location) to specify a circle bias
-    let inputBounds, inputLocation;
-    if (locationBias) {
-      // MigrationLatLng|LatLngLiteral
-      if (locationBias.lat !== undefined && locationBias.lng !== undefined) {
-        inputLocation = new MigrationLatLng(locationBias);
-      } /* MigrationLatLngBounds|LatLngBoundsLiteral */ else {
-        inputBounds = new MigrationLatLngBounds(locationBias);
-      }
-    } else if (bounds) {
-      inputBounds = new MigrationLatLngBounds(bounds);
-    } else if (location) {
-      inputLocation = new MigrationLatLng(location);
-    }
-
-    // If bounds was found, then location is ignored
-    if (inputBounds) {
-      const southWest = inputBounds.getSouthWest();
-      const northEast = inputBounds.getNorthEast();
-
-      input.Filter = {
-        BoundingBox: [southWest.lng(), southWest.lat(), northEast.lng(), northEast.lat()],
-      };
-    } else if (inputLocation) {
-      // If we have a location and a radius, then we will use a circle
-      // Otherwise, just the location will be used
-      const lngLat = LatLngToLngLat(inputLocation);
-      if (lngLat) {
-        if (radius) {
-          input.Filter = {
-            Circle: {
-              Center: lngLat,
-              Radius: radius,
-            },
-          };
-        } else {
-          input.BiasPosition = lngLat;
-        }
-      }
-    }
+    // Set the appropriate location bias on our request input
+    setRequestLocationBias(input, location, locationBias, bounds, radius);
 
     if (language) {
       input.Language = language;
@@ -95,7 +102,7 @@ export class MigrationAutocompleteService {
     this._client
       .send(command)
       .then((response) => {
-        const googlePredictions: QueryAutocompletePrediction[] = [];
+        const googlePredictions: google.maps.places.QueryAutocompletePrediction[] = [];
 
         const results = response.ResultItems;
         if (results && results.length !== 0) {
@@ -155,7 +162,7 @@ export class MigrationAutocompleteService {
               });
             }
 
-            const prediction: QueryAutocompletePrediction = {
+            const prediction: google.maps.places.QueryAutocompletePrediction = {
               description: result.Query ? result.Title : result.Place.Address.Label,
               matched_substrings: matchedSubstrings,
               terms: terms,
@@ -164,7 +171,6 @@ export class MigrationAutocompleteService {
             if (result.Place) {
               const placeId = result.Place.PlaceId;
               prediction.place_id = placeId;
-              prediction.reference = placeId;
             }
 
             googlePredictions.push(prediction);
@@ -182,23 +188,117 @@ export class MigrationAutocompleteService {
 
   // getPlacePredictions has a similar behavior as getQueryPredictions, except it omits query predictions,
   // so it only returns predictions that have a place_id
-  getPlacePredictions(request, callback?): Promise<AutocompleteResponse> {
-    return new Promise((resolve) => {
-      this.getQueryPredictions(request, (predictions, status) => {
-        // Filter out predictions that don't have a place_id
-        const filteredPredictions = predictions.filter((prediction) => {
-          return prediction.place_id;
-        });
+  // https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService.getPlacePredictions
+  getPlacePredictions(request, callback?): Promise<google.maps.places.AutocompleteResponse> {
+    return new Promise((resolve, reject) => {
+      const query = request.input;
+      const location = request.location; // optional
+      const locationBias = request.locationBias; // optional
+      const bounds = request.bounds || request.locationRestriction; // optional
+      const radius = request.radius; // optional
+      const language = request.language; // optional
 
-        // If a callback was given, invoke it before resolving the promise
-        if (callback) {
-          callback(filteredPredictions, status);
-        }
+      const input: AutocompleteRequest = {
+        QueryText: query, // required
+        MaxResults: 5, // Google only returns a max of 5 results
+        AdditionalFeatures: [SuggestAdditionalFeature.CORE], // Without this, only the ID and Title will be returned
+      };
 
-        resolve({
-          predictions: filteredPredictions,
+      // Set the appropriate location bias on our request input
+      setRequestLocationBias(input, location, locationBias, bounds, radius);
+
+      if (language) {
+        input.Language = language;
+      }
+
+      const command = new AutocompleteCommand(input);
+
+      this._client
+        .send(command)
+        .then((response) => {
+          const googlePredictions: google.maps.places.AutocompletePrediction[] = [];
+
+          const results = response.ResultItems;
+          if (results && results.length !== 0) {
+            results.forEach(function (result) {
+              const matchedSubstrings = [];
+              const addressHighlights = result.Highlights?.Address;
+              if (addressHighlights) {
+                Object.keys(addressHighlights).forEach((key) => {
+                  const highlights = addressHighlights[key];
+                  if (Array.isArray(highlights)) {
+                    highlights.forEach((highlight) => {
+                      matchedSubstrings.push({
+                        length: highlight.EndIndex - highlight.StartIndex,
+                        offset: highlight.StartIndex,
+                      });
+                    });
+                  }
+                });
+              }
+
+              const terms: google.maps.places.PredictionTerm[] = [];
+              const description = result.Address.Label;
+              let offset = 0;
+              for (let index = 0; index < description.length; index++) {
+                if (description[index] == ",") {
+                  terms.push({
+                    offset: offset,
+                    value: description.substring(offset, index),
+                  });
+
+                  // The label parts are separated by a comma and a space, so advance the index and calculate
+                  // the next offset based on that the index will also be incremented after completing this iteration
+                  // of the loop
+                  index++;
+                  offset = index + 1;
+                }
+              }
+
+              terms.push({
+                offset: offset,
+                value: description.substring(offset),
+              });
+
+              const prediction: google.maps.places.AutocompletePrediction = {
+                description: result.Address.Label,
+                matched_substrings: matchedSubstrings,
+                place_id: result.PlaceId,
+                terms: terms,
+                structured_formatting: {
+                  main_text: result.Address.Label,
+                  main_text_matched_substrings: matchedSubstrings,
+                  secondary_text: result.Address.Locality,
+                },
+                // These are not currently supported, but are required in the response
+                types: [],
+              };
+
+              googlePredictions.push(prediction);
+            });
+          }
+
+          // If a callback was given, invoke it before resolving the promise
+          if (callback) {
+            callback(googlePredictions, PlacesServiceStatus.OK);
+          }
+
+          resolve({
+            predictions: googlePredictions,
+          });
+        })
+        .catch((error) => {
+          console.error(error);
+
+          // If a callback was given, invoke it before rejecting the promise
+          if (callback) {
+            callback([], PlacesServiceStatus.UNKNOWN_ERROR);
+          }
+
+          reject({
+            status: PlacesServiceStatus.UNKNOWN_ERROR,
+          });
         });
-      });
     });
   }
 }

--- a/src/places/autocomplete_service.ts
+++ b/src/places/autocomplete_service.ts
@@ -12,8 +12,34 @@ import {
 
 import { LatLngToLngLat, MigrationLatLng, MigrationLatLngBounds, PlacesServiceStatus } from "../common";
 
-// Handle location/bounds restrictions. bounds and location have been deprecated, and in some cases
-// have actually been removed (although still mentioned in the documentation as only deprecated).
+// We override/extend the base provided types for QueryAutocompletionRequest and AutocompletionRequest,
+// because of various inconsistencies in Google's documentation vs. implementation:
+//    * Fields that are only marked deprecated, but actually no longer appear in the published types, but can still be passed to the API
+//    * Old fields that have been documented as removed, but still function
+//    * Fields that are documented to only accept a single sub-type but actually accept more
+//
+interface QueryAutocompletionRequest extends Omit<google.maps.places.QueryAutocompletionRequest, "location"> {
+  location?: google.maps.LatLng | google.maps.LatLngLiteral | null;
+  locationBias?:
+    | google.maps.LatLng
+    | google.maps.LatLngLiteral
+    | google.maps.LatLngBounds
+    | google.maps.LatLngBoundsLiteral
+    | null;
+  locationRestriction?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | null;
+  language?: string;
+}
+interface AutocompletionRequest extends google.maps.places.AutocompletionRequest {
+  locationBias?:
+    | google.maps.LatLng
+    | google.maps.LatLngLiteral
+    | google.maps.LatLngBounds
+    | google.maps.LatLngBoundsLiteral
+    | null;
+}
+
+// Handle setting the appropriate location bias on our Amazon Location requests based on
+// which fields were provided from the corresponding Google request.
 //   * locationBias is the top preferred field, and can be MigrationLatLng|LatLngLiteral|MigrationLatLngBounds|LatLngBoundsLiteral
 //   * bounds / locationRestriction is the next preferred field
 //   * location is the final field that is checked
@@ -21,15 +47,20 @@ import { LatLngToLngLat, MigrationLatLng, MigrationLatLngBounds, PlacesServiceSt
 // This logic can be shared between both getQueryPredictions and getPlacePredictions
 const setRequestLocationBias = (
   input: AutocompleteRequest | SuggestRequest,
-  location,
-  locationBias,
-  bounds,
-  radius,
+  location: google.maps.LatLng | google.maps.LatLngLiteral | null,
+  locationBias:
+    | google.maps.LatLng
+    | google.maps.LatLngLiteral
+    | google.maps.LatLngBounds
+    | google.maps.LatLngBoundsLiteral
+    | null,
+  bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | null,
+  radius: number | null,
 ) => {
   let inputBounds, inputLocation;
   if (locationBias) {
     // MigrationLatLng|LatLngLiteral
-    if (locationBias.lat !== undefined && locationBias.lng !== undefined) {
+    if ("lat" in locationBias && "lng" in locationBias) {
       inputLocation = new MigrationLatLng(locationBias);
     } /* MigrationLatLngBounds|LatLngBoundsLiteral */ else {
       inputBounds = new MigrationLatLngBounds(locationBias);
@@ -74,8 +105,8 @@ export class MigrationAutocompleteService {
 
   // https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService.getQueryPredictions
   getQueryPredictions(
-    request,
-    callback: (a: google.maps.places.QueryAutocompletePrediction[], b: PlacesServiceStatus) => void,
+    request: QueryAutocompletionRequest,
+    callback: (predictions: google.maps.places.QueryAutocompletePrediction[], status: PlacesServiceStatus) => void,
   ) {
     const query = request.input;
     const location = request.location; // optional
@@ -189,7 +220,13 @@ export class MigrationAutocompleteService {
   // getPlacePredictions has a similar behavior as getQueryPredictions, except it omits query predictions,
   // so it only returns predictions that have a place_id
   // https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteService.getPlacePredictions
-  getPlacePredictions(request, callback?): Promise<google.maps.places.AutocompleteResponse> {
+  getPlacePredictions(
+    request: AutocompletionRequest,
+    callback?: (
+      predictions: google.maps.places.AutocompletePrediction[] | null,
+      status: google.maps.places.PlacesServiceStatus,
+    ) => void,
+  ): Promise<google.maps.places.AutocompleteResponse> {
     return new Promise((resolve, reject) => {
       const query = request.input;
       const location = request.location; // optional


### PR DESCRIPTION
### Description
Updated `getPlacePredictions` to use the new `Autocomplete` API in the `GeoPlaces` client SDK. The previous implementation simply invoked `getQueryPredictions` and then filtered out any results that didn't have a `PlaceId`. In the new `GeoPlaces` client, we have the `Autocomplete` API that only returns concrete places, instead of a mix of places + query suggestions.

As part of this change, the logic for parsing the location bias was moved to a shared helper, and this also allowed us to remove the temporary custom types since we were previously invoking `getQueryPredictions` under the hood.

### Testing
Ran unit tests and verified all modified/added logic still has 100% coverage.

```
 PASS  test/markers.test.ts
 PASS  test/directions.test.ts
 PASS  test/infoWindow.test.ts
 PASS  test/places.test.ts
 PASS  test/events.test.ts
 PASS  test/maps.test.ts
 PASS  test/index.test.ts
 PASS  test/googleCommon.test.ts
-----------------------------|---------|----------|---------|---------|-------------------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------|---------|----------|---------|---------|-------------------------------
All files                    |   98.94 |    94.29 |    98.6 |   98.93 |
 src                         |     100 |    96.92 |     100 |     100 |
  events.ts                  |     100 |    94.59 |     100 |     100 | 20
  geocoder.ts                |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  version.ts                 |     100 |      100 |     100 |     100 |
 src/common                  |   97.74 |     89.6 |   96.29 |   97.73 |
  circle.ts                  |   93.45 |    81.15 |   94.11 |   93.45 | 214-218,231-236
  defines.ts                 |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  lat_lng.ts                 |     100 |      100 |     100 |     100 |
  lat_lng_bounds.ts          |     100 |      100 |     100 |     100 |
  mvc_object.ts              |     100 |      100 |   88.88 |     100 |
 src/directions              |     100 |    93.67 |     100 |     100 |
  defines.ts                 |     100 |      100 |     100 |     100 |
  directions_renderer.ts     |     100 |      100 |     100 |     100 |
  directions_service.ts      |     100 |      100 |     100 |     100 |
  distance_matrix_service.ts |     100 |      100 |     100 |     100 |
  helpers.ts                 |     100 |    80.76 |     100 |     100 | 38-39,62,76-108
  index.ts                   |     100 |      100 |     100 |     100 |
 src/maps                    |   96.54 |    90.25 |   97.05 |   96.54 |
  index.ts                   |     100 |      100 |     100 |     100 |
  info_window.ts             |     100 |    95.65 |     100 |     100 | 118
  map.ts                     |    99.3 |    96.73 |   96.42 |    99.3 | 87
  marker.ts                  |   92.07 |    81.63 |      95 |   92.07 | 89-94,117-119,166,367,370,373
 src/places                  |     100 |    97.56 |     100 |     100 |
  autocomplete.ts            |     100 |      100 |     100 |     100 |
  autocomplete_service.ts    |     100 |       85 |     100 |     100 | 129-131,225
  index.ts                   |     100 |      100 |     100 |     100 |
  opening_hours.ts           |     100 |      100 |     100 |     100 |
  place.ts                   |     100 |      100 |     100 |     100 |
  place_conversion.ts        |     100 |      100 |     100 |     100 |
  place_types.ts             |     100 |      100 |     100 |     100 |
  places_service.ts          |     100 |    97.91 |     100 |     100 | 223
  searchbox.ts               |     100 |    95.23 |     100 |     100 | 79
-----------------------------|---------|----------|---------|---------|-------------------------------
```

Built/ran local examples and verified they still work as expected. Verified the `getPlacePredictions` still only returns concrete places.