### PR TITLE
Updated new Place fetchFields to use standalone GeoPlaces client SDK

### DIFF
--- a/examples/autoComplete/index.template.html
+++ b/examples/autoComplete/index.template.html
@@ -19,6 +19,6 @@
     <div id="map"></div>
 
     <!-- Migration script import -->
-    <script src="../../dist/amazonLocationMigrationSDK.js?region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
+    <script src="../../dist/amazonLocationMigrationSDK.js?region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
   </body>
 </html>

--- a/examples/basicMap/index.template.html
+++ b/examples/basicMap/index.template.html
@@ -14,7 +14,7 @@
     <script
       async
       defer
-      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
+      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/examples/markers/index.template.html
+++ b/examples/markers/index.template.html
@@ -14,7 +14,7 @@
     <script
       async
       defer
-      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
+      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/examples/nearbySearch/index.template.html
+++ b/examples/nearbySearch/index.template.html
@@ -25,7 +25,7 @@
     <script
       async
       defer
-      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&map={{MAP_NAME}}&placeIndex={{PLACE_INDEX}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
+      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
     ></script>
   </body>
 </html>

--- a/src/places/place_conversion.ts
+++ b/src/places/place_conversion.ts
@@ -495,11 +495,50 @@ const convertAmazonPlaceToGoogleV1 = (placeObject, fields, includeDetailFields) 
   return googlePlace;
 };
 
+// Since we use convertAmazonPlaceToGoogle to convert the Amazon Place response to
+// a Google PlaceResult, we need to map the new Place property fields to the corrresponding
+// PlaceResult fields so that the proper fields are parsed/filtered when specified
+const newFieldToPlaceResultFieldMapping: { [key: string]: string } = {
+  addressComponents: "address_components",
+  adrFormatAddress: "adr_address",
+  displayName: "name",
+  formattedAddress: "formatted_address",
+  id: "place_id",
+  internationalPhoneNumber: "international_phone_number",
+  location: "geometry.location",
+  nationalPhoneNumber: "formatted_phone_number",
+  openingHours: "opening_hours",
+  plusCode: "plus_code",
+  regularOpeningHours: "opening_hours",
+  types: "types",
+  utcOffsetMinutes: "utc_offset_minutes",
+  viewport: "geometry.viewport",
+  websiteURI: "website",
+  "*": "ALL",
+};
+const convertNewFieldsToPlaceResultFields = (fields: string[] | null): string[] => {
+  if (!fields) {
+    return [];
+  }
+
+  const placeResultFields: string[] = [];
+  fields.forEach((field) => {
+    if (field in newFieldToPlaceResultFieldMapping) {
+      placeResultFields.push(newFieldToPlaceResultFieldMapping[field]);
+    } else {
+      console.warn("Unsupported field:", field);
+    }
+  });
+
+  return placeResultFields;
+};
+
 export {
   convertAmazonCategoriesToGoogle,
   convertAmazonPlaceToGoogle,
   convertAmazonPlaceToGoogleV1,
   convertGeocoderAddressComponentToAddressComponent,
   convertPlacePlusCodeToPlusCode,
+  convertNewFieldsToPlaceResultFields,
   PlaceResult,
 };

--- a/test/place_conversion.test.ts
+++ b/test/place_conversion.test.ts
@@ -5,11 +5,12 @@ import {
   convertAmazonCategoriesToGoogle,
   convertAmazonPlaceToGoogle,
   convertGeocoderAddressComponentToAddressComponent,
+  convertNewFieldsToPlaceResultFields,
   convertPlacePlusCodeToPlusCode,
 } from "../src/places";
 
-// Spy on console.error so we can verify it gets called in error cases
-jest.spyOn(console, "error").mockImplementation(() => {});
+// Spy on console.warn so we can verify it gets called in warning cases
+jest.spyOn(console, "warn").mockImplementation(() => {});
 
 // Set a fake system time so that any logic that creates a new Date.now (e.g. new Date())
 // will be deterministic
@@ -460,4 +461,24 @@ test("address component conversion should handle null input", () => {
 test("plus code conversion should handle null input", () => {
   const plusCode = convertPlacePlusCodeToPlusCode(null);
   expect(plusCode).toBeNull();
+});
+
+test("fields conversion should handle null input", () => {
+  const fields = convertNewFieldsToPlaceResultFields(null);
+  expect(fields).toHaveLength(0);
+});
+
+test("fields conversion should handle multiple field conversions", () => {
+  const fields = ["addressComponents", "displayName", "*"];
+
+  const newFields = convertNewFieldsToPlaceResultFields(fields);
+  expect(newFields).toStrictEqual(["address_components", "name", "ALL"]);
+});
+
+test("fields conversion should throw warning for unsupported fields", () => {
+  const fields = ["addressComponents", "googleMapsURI", "displayName"];
+
+  const newFields = convertNewFieldsToPlaceResultFields(fields);
+  expect(newFields).toStrictEqual(["address_components", "name"]);
+  expect(console.warn).toHaveBeenCalledTimes(1);
 });

--- a/test/places.test.ts
+++ b/test/places.test.ts
@@ -57,27 +57,6 @@ const mockedClientSendV1 = jest.fn((command) => {
           ],
         });
       }
-    } else if (command instanceof GetPlaceCommandV1) {
-      if (command.input.PlaceId === undefined || command.input.PlaceId === clientErrorQuery) {
-        // Return an empty object that will throw an error
-        resolve({});
-      } else {
-        resolve({
-          Place: {
-            Label: testPlaceWithAddressLabel,
-            AddressNumber: "1337",
-            Street: "Cool Place Road",
-            Geometry: {
-              Point: [testLng, testLat],
-            },
-            TimeZone: {
-              Offset: -18000,
-            },
-            Municipality: "Austin",
-            Categories: ["City"],
-          },
-        });
-      }
     } else if (command instanceof SearchPlaceIndexForSuggestionsCommand) {
       if (command.input.Text == clientErrorQuery) {
         // Return an empty object that will throw an error
@@ -110,7 +89,6 @@ jest.mock("@aws-sdk/client-location", () => ({
   }),
 }));
 import {
-  GetPlaceCommand as GetPlaceCommandV1,
   LocationClient,
   SearchPlaceIndexForSuggestionsCommand,
   SearchPlaceIndexForTextCommand,
@@ -519,6 +497,7 @@ import {
   SearchNearbyRequest,
   SearchTextCommand,
   SearchTextRequest,
+  GetPlaceRequest,
 } from "@aws-sdk/client-geo-places";
 
 const autocompleteService = new MigrationAutocompleteService();
@@ -2380,8 +2359,8 @@ test("fetchFields should return only specified fields", async () => {
     fields: ["formattedAddress", "location"],
   });
 
-  expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-  expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(GetPlaceCommandV1));
+  expect(mockedClientSend).toHaveBeenCalledTimes(1);
+  expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
 
   // Properties for the requested fields on the newPlace instance should
   // be filled in after calling fetchFields
@@ -2412,8 +2391,8 @@ test("fetchFields should return all fields if specified", async () => {
     fields: ["*"],
   });
 
-  expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-  expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(GetPlaceCommandV1));
+  expect(mockedClientSend).toHaveBeenCalledTimes(1);
+  expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
 
   // Properties for all fields on the newPlace instance should
   // be filled in after calling fetchFields
@@ -2439,9 +2418,9 @@ test("fetchFields should pass language if specified", async () => {
     fields: ["*"],
   });
 
-  expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-  expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(GetPlaceCommandV1));
-  const clientInput = mockedClientSendV1.mock.calls[0][0].input;
+  expect(mockedClientSend).toHaveBeenCalledTimes(1);
+  expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+  const clientInput: GetPlaceRequest = mockedClientSend.mock.calls[0][0].input;
 
   expect(clientInput.Language).toStrictEqual("en");
 


### PR DESCRIPTION
### Description
Updated the `fetchFields` API on `Place` class to use the new standalone `GeoPlaces` client SDK `GetPlace` command.

Removed the `GetPlaceCommandV1` mocked response in our tests since there are no longer any APIs using the V1 `GetPlaceCommand`.

Also updated several examples to remove the passing in of map resource and place index, since these are no longer necessary.

### Testing
Ran unit tests and verified we retained 100% coverage on modified + new logic added. Also built and ran the local examples and verified they still work as expected.

```
 PASS  test/geocoder.test.ts
 PASS  test/opening_hours.test.ts
 PASS  test/place_conversion.test.ts
 PASS  test/places.test.ts (5.18 s)
 PASS  test/markers.test.ts (5.345 s)
 PASS  test/directions.test.ts (5.435 s)
 PASS  test/infoWindow.test.ts (5.492 s)
 PASS  test/googleCommon.test.ts (5.474 s)
 PASS  test/maps.test.ts (5.51 s)
 PASS  test/index.test.ts (5.528 s)
 PASS  test/events.test.ts (5.519 s)
-----------------------------|---------|----------|---------|---------|-------------------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------|---------|----------|---------|---------|-------------------------------
All files                    |   99.01 |    94.25 |   98.68 |      99 |
 src                         |     100 |    96.92 |     100 |     100 |
  events.ts                  |     100 |    94.59 |     100 |     100 | 20
  geocoder.ts                |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  version.ts                 |     100 |      100 |     100 |     100 |
 src/common                  |   97.74 |     89.6 |   96.29 |   97.73 |
  circle.ts                  |   93.45 |    81.15 |   94.11 |   93.45 | 214-218,231-236
  defines.ts                 |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  lat_lng.ts                 |     100 |      100 |     100 |     100 |
  lat_lng_bounds.ts          |     100 |      100 |     100 |     100 |
  mvc_object.ts              |     100 |      100 |   88.88 |     100 |
 src/directions              |     100 |    93.67 |     100 |     100 |
  defines.ts                 |     100 |      100 |     100 |     100 |
  directions_renderer.ts     |     100 |      100 |     100 |     100 |
  directions_service.ts      |     100 |      100 |     100 |     100 |
  distance_matrix_service.ts |     100 |      100 |     100 |     100 |
  helpers.ts                 |     100 |    80.76 |     100 |     100 | 38-39,62,76-108
  index.ts                   |     100 |      100 |     100 |     100 |
 src/maps                    |   96.54 |    90.25 |   97.05 |   96.54 |
  index.ts                   |     100 |      100 |     100 |     100 |
  info_window.ts             |     100 |    95.65 |     100 |     100 | 118
  map.ts                     |    99.3 |    96.73 |   96.42 |    99.3 | 87
  marker.ts                  |   92.07 |    81.63 |      95 |   92.07 | 89-94,117-119,166,367,370,373
 src/places                  |     100 |    97.27 |     100 |     100 |
  autocomplete.ts            |     100 |      100 |     100 |     100 |
  autocomplete_service.ts    |     100 |       85 |     100 |     100 | 160-162,262
  defines.ts                 |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  opening_hours.ts           |     100 |      100 |     100 |     100 |
  place.ts                   |     100 |    95.65 |     100 |     100 | 100-107
  place_conversion.ts        |     100 |      100 |     100 |     100 |
  place_types.ts             |     100 |      100 |     100 |     100 |
  places_service.ts          |     100 |    97.91 |     100 |     100 | 223
  searchbox.ts               |     100 |    95.23 |     100 |     100 | 79
-----------------------------|---------|----------|---------|---------|-------------------------------

Test Suites: 11 passed, 11 total
Tests:       347 passed, 347 total
Snapshots:   0 total
Time:        6.783 s
Ran all test suites.
```