### PR TITLE
Added findPlaceFromPhoneNumber support

### DIFF
--- a/documentation/placesService.md
+++ b/documentation/placesService.md
@@ -4,7 +4,7 @@
 
 | [Methods](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService-Methods)                                   | Supported          | Notes                                            |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------ |
-| [findPlaceFromPhoneNumber](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.findPlaceFromPhoneNumber) | :x:                |                                                  |
+| [findPlaceFromPhoneNumber](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.findPlaceFromPhoneNumber) | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md). |
 | [findPlaceFromQuery](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.findPlaceFromQuery)             | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md). |
 | [getDetails](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.getDetails)                             | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md)  |
 | [nearbySearch](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.nearbySearch)                         | :white_check_mark: | `PlaceResult` has [limitations](placeResult.md)  |

--- a/src/places/places_service.ts
+++ b/src/places/places_service.ts
@@ -18,11 +18,37 @@ import {
   MigrationLatLngBounds,
   PlacesServiceStatus,
 } from "../common";
-import { convertAmazonPlaceToGoogle } from "./place_conversion";
+import { convertAmazonPlaceToGoogle, PlaceResult } from "./place_conversion";
 import { getAllAmazonPlaceTypesFromGoogle } from "./place_types";
 
 class MigrationPlacesService {
   _client: GeoPlacesClient; // This will be populated by the top level module that creates our location client
+
+  // https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/places-service#PlacesService.findPlaceFromPhoneNumber
+  findPlaceFromPhoneNumber(
+    request: google.maps.places.FindPlaceFromPhoneNumberRequest,
+    callback: (results: PlaceResult[] | null, status: google.maps.places.PlacesServiceStatus) => void,
+  ) {
+    const phoneNumber = request.phoneNumber; // required
+    const fields = request.fields; // required
+    const locationBias = request.locationBias; // optional
+    const language = request.language; // optional
+
+    // The findPlaceFromPhoneNumber request is accomplished using the same underlying
+    // Amazon Location API (SearchText) as findPlaceFromQuery. The phoneNumber input
+    // field is just passed as the query input for findPlaceFromQuery, and then it also
+    // supports locationBias, fields, and language.
+    const input: google.maps.places.FindPlaceFromQueryRequest = {
+      query: phoneNumber,
+      locationBias: locationBias,
+      fields: fields,
+      language: language,
+    };
+
+    this.findPlaceFromQuery(input, (results, status) => {
+      callback(results, status);
+    });
+  }
 
   findPlaceFromQuery(request: google.maps.places.FindPlaceFromQueryRequest, callback) {
     const query = request.query;


### PR DESCRIPTION
### Description
Added migration support for the `findPlaceFromPhoneNumber` API. This uses the same underlying Amazon Location API (`SearchText`) as `findPlaceFromQuery`.

### Testing
Added unit tests to retain 100% coverage of all logic added, including the different input fields that can be passed to `findPlaceFromPhoneNumber`. Also built and ran the local examples and verified they still work as expected.

```
 PASS  test/place_conversion.test.ts (6.014 s)
 PASS  test/opening_hours.test.ts (6.031 s)
 PASS  test/markers.test.ts (6.238 s)
 PASS  test/maps.test.ts (6.228 s)
 PASS  test/geocoder.test.ts (6.28 s)
 PASS  test/infoWindow.test.ts (6.247 s)
 PASS  test/googleCommon.test.ts (6.334 s)
 PASS  test/events.test.ts (6.372 s)
 PASS  test/index.test.ts (6.39 s)
 PASS  test/directions.test.ts (6.43 s)
 PASS  test/places.test.ts (6.615 s)
-----------------------------|---------|----------|---------|---------|-------------------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------|---------|----------|---------|---------|-------------------------------
All files                    |      99 |    94.43 |   98.68 |      99 |
 src                         |     100 |    96.92 |     100 |     100 |
  events.ts                  |     100 |    94.59 |     100 |     100 | 20
  geocoder.ts                |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  version.ts                 |     100 |      100 |     100 |     100 |
 src/common                  |   97.74 |     89.6 |   96.29 |   97.73 |
  circle.ts                  |   93.45 |    81.15 |   94.11 |   93.45 | 214-218,231-236
  defines.ts                 |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  lat_lng.ts                 |     100 |      100 |     100 |     100 |
  lat_lng_bounds.ts          |     100 |      100 |     100 |     100 |
  mvc_object.ts              |     100 |      100 |   88.88 |     100 |
 src/directions              |     100 |    93.67 |     100 |     100 |
  defines.ts                 |     100 |      100 |     100 |     100 |
  directions_renderer.ts     |     100 |      100 |     100 |     100 |
  directions_service.ts      |     100 |      100 |     100 |     100 |
  distance_matrix_service.ts |     100 |      100 |     100 |     100 |
  helpers.ts                 |     100 |    80.76 |     100 |     100 | 38-39,62,76-108
  index.ts                   |     100 |      100 |     100 |     100 |
 src/maps                    |   96.54 |    90.25 |   97.05 |   96.54 |
  index.ts                   |     100 |      100 |     100 |     100 |
  info_window.ts             |     100 |    95.65 |     100 |     100 | 118
  map.ts                     |    99.3 |    96.73 |   96.42 |    99.3 | 87
  marker.ts                  |   92.07 |    81.63 |      95 |   92.07 | 89-94,117-119,166,367,370,373
 src/places                  |     100 |    97.69 |     100 |     100 |
  autocomplete.ts            |     100 |      100 |     100 |     100 |
  autocomplete_service.ts    |     100 |       85 |     100 |     100 | 160-162,262
  defines.ts                 |     100 |      100 |     100 |     100 |
  index.ts                   |     100 |      100 |     100 |     100 |
  opening_hours.ts           |     100 |      100 |     100 |     100 |
  place.ts                   |     100 |      100 |     100 |     100 |
  place_conversion.ts        |     100 |      100 |     100 |     100 |
  place_types.ts             |     100 |      100 |     100 |     100 |
  places_service.ts          |     100 |    97.91 |     100 |     100 | 245
  searchbox.ts               |     100 |    95.23 |     100 |     100 | 79
-----------------------------|---------|----------|---------|---------|-------------------------------

Test Suites: 11 passed, 11 total
Tests:       363 passed, 363 total
Snapshots:   0 total
Time:        8.001 s
Ran all test suites.
```