### PR TITLE
Added routes V2 support at current parity

### DIFF
--- a/documentation/directions.md
+++ b/documentation/directions.md
@@ -25,6 +25,13 @@
 | [unitSystem](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/directions#DirectionsRequest.unitSystem)                             | :white_check_mark: |                                       |
 | [waypoints](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/directions#DirectionsRequest.waypoints)                               | :white_check_mark: |                                       |
 
+### [DirectionsWaypoint interface](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/directions#DirectionsWaypoint)
+
+| [Properties](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/directions#DirectionsWaypoint-Properties) | Supported          | Notes |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| [location](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/directions#DirectionsWaypoint.location)     | :white_check_mark: |       |
+| [stopover](https://developers-dot-devsite-v2-prod.appspot.com/maps/documentation/javascript/reference/directions#DirectionsWaypoint.stopover)     | :white_check_mark: |       |
+
 ### [DirectionsResult interface](https://developers.google.com/maps/documentation/javascript/reference/directions#DirectionsResult)
 
 | [Properties](https://developers.google.com/maps/documentation/javascript/reference/directions#DirectionsResult-Properties)                         | Supported          | Notes                                                                   |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-geo-places": "^3.699.0",
-        "@aws-sdk/client-location": "^3.699.0",
+        "@aws-sdk/client-geo-places": "^3.808.0",
+        "@aws-sdk/client-geo-routes": "3.808.0",
+        "@aws-sdk/client-location": "^3.808.0",
         "@aws/amazon-location-for-maplibre-gl-geocoder": "^2.0.2",
-        "@aws/amazon-location-utilities-auth-helper": "^1.2.1",
+        "@aws/amazon-location-utilities-auth-helper": "^1.2.2",
         "@turf/turf": "^7.1.0",
         "libphonenumber-js": "^1.11.16",
         "maplibre-gl": "^5.5.0",
@@ -121,862 +122,859 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.699.0.tgz",
-      "integrity": "sha512-9tFt+we6AIvj/f1+nrLHuCWcQmyfux5gcBSOy9d9+zIG56YxGEX7S9TaZnybogpVV8A0BYWml36WvIHS9QjIpA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.808.0.tgz",
+      "integrity": "sha512-M9pdFQ+Efl1O4No6R7uMEOkidKVUiNsmN13EyzuIOGech9g+RF+LgDn3n8+PuC7EIgndQVe6sQ6w39sPQdBkww==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.699.0",
-        "@aws-sdk/client-sts": "3.699.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.699.0",
-        "@aws-sdk/middleware-host-header": "3.696.0",
-        "@aws-sdk/middleware-logger": "3.696.0",
-        "@aws-sdk/middleware-recursion-detection": "3.696.0",
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/region-config-resolver": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@aws-sdk/util-user-agent-browser": "3.696.0",
-        "@aws-sdk/util-user-agent-node": "3.696.0",
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/core": "^2.5.3",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/hash-node": "^3.0.10",
-        "@smithy/invalid-dependency": "^3.0.10",
-        "@smithy/middleware-content-length": "^3.0.12",
-        "@smithy/middleware-endpoint": "^3.2.3",
-        "@smithy/middleware-retry": "^3.0.27",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.27",
-        "@smithy/util-defaults-mode-node": "^3.0.27",
-        "@smithy/util-endpoints": "^2.1.6",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-geo-places": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-geo-places/-/client-geo-places-3.699.0.tgz",
-      "integrity": "sha512-+30mTbQLtz8uNw9zX1ceyFGZDIG37kQLQ05HgG16Lfz8RyK7jnLeJj22ts9yF9Zlq7E+WLiI/bryvNrpWpJaZQ==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-geo-places/-/client-geo-places-3.808.0.tgz",
+      "integrity": "sha512-DW8Zqux0jVfmP61qGKf+P+Anc7oFrjTqq/i1q+T5UW7qDRnTxkle0Dejtsq2GySMfYJk+lqMV0MxvSE3PNLOfA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.699.0",
-        "@aws-sdk/client-sts": "3.699.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.699.0",
-        "@aws-sdk/middleware-host-header": "3.696.0",
-        "@aws-sdk/middleware-logger": "3.696.0",
-        "@aws-sdk/middleware-recursion-detection": "3.696.0",
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/region-config-resolver": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@aws-sdk/util-user-agent-browser": "3.696.0",
-        "@aws-sdk/util-user-agent-node": "3.696.0",
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/core": "^2.5.3",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/hash-node": "^3.0.10",
-        "@smithy/invalid-dependency": "^3.0.10",
-        "@smithy/middleware-content-length": "^3.0.12",
-        "@smithy/middleware-endpoint": "^3.2.3",
-        "@smithy/middleware-retry": "^3.0.27",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.27",
-        "@smithy/util-defaults-mode-node": "^3.0.27",
-        "@smithy/util-endpoints": "^2.1.6",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-geo-places/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-geo-places/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-geo-places/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-geo-routes": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-geo-routes/-/client-geo-routes-3.808.0.tgz",
+      "integrity": "sha512-ug8o8KOxXJj+ZNrC+67LF1OWAuz1/OB2RvCZhEfPcJD8YTXZtKtn6aMjSpDYF/JNqNxBqTvrqU22JjLrmxp2oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-geo-routes/node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-geo-routes/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-geo-routes/node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-location": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.699.0.tgz",
-      "integrity": "sha512-kO+Qck0lX7slUvgcZWtntvB6Tfy7k+ybVmn1hnuaqjmx6+km4mOcE9yz8urKhhRVMJ5rUk3gbpxvofxS+x3nsA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.808.0.tgz",
+      "integrity": "sha512-9Yw77Y6aLSYXlLFiwfiVejetmNglcMAV/IcjFO89vSGOFU45vri8o58ozqVQV1vaZ3z5A312qqik4sJskZLkrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.699.0",
-        "@aws-sdk/client-sts": "3.699.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.699.0",
-        "@aws-sdk/middleware-host-header": "3.696.0",
-        "@aws-sdk/middleware-logger": "3.696.0",
-        "@aws-sdk/middleware-recursion-detection": "3.696.0",
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/region-config-resolver": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@aws-sdk/util-user-agent-browser": "3.696.0",
-        "@aws-sdk/util-user-agent-node": "3.696.0",
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/core": "^2.5.3",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/hash-node": "^3.0.10",
-        "@smithy/invalid-dependency": "^3.0.10",
-        "@smithy/middleware-content-length": "^3.0.12",
-        "@smithy/middleware-endpoint": "^3.2.3",
-        "@smithy/middleware-retry": "^3.0.27",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.27",
-        "@smithy/util-defaults-mode-node": "^3.0.27",
-        "@smithy/util-endpoints": "^2.1.6",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
-        "@smithy/util-stream": "^3.3.1",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-location/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-location/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-location/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
-      "integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.808.0.tgz",
+      "integrity": "sha512-NxGomD0x9q30LPOXf4x7haOm6l2BJdLEzpiC/bPEXUkf2+4XudMQumMA/hDfErY5hCE19mFAouoO465m3Gl3JQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/middleware-host-header": "3.696.0",
-        "@aws-sdk/middleware-logger": "3.696.0",
-        "@aws-sdk/middleware-recursion-detection": "3.696.0",
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/region-config-resolver": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@aws-sdk/util-user-agent-browser": "3.696.0",
-        "@aws-sdk/util-user-agent-node": "3.696.0",
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/core": "^2.5.3",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/hash-node": "^3.0.10",
-        "@smithy/invalid-dependency": "^3.0.10",
-        "@smithy/middleware-content-length": "^3.0.12",
-        "@smithy/middleware-endpoint": "^3.2.3",
-        "@smithy/middleware-retry": "^3.0.27",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.27",
-        "@smithy/util-defaults-mode-node": "^3.0.27",
-        "@smithy/util-endpoints": "^2.1.6",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
-        "@smithy/util-utf8": "^3.0.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
-      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.699.0",
-        "@aws-sdk/middleware-host-header": "3.696.0",
-        "@aws-sdk/middleware-logger": "3.696.0",
-        "@aws-sdk/middleware-recursion-detection": "3.696.0",
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/region-config-resolver": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@aws-sdk/util-user-agent-browser": "3.696.0",
-        "@aws-sdk/util-user-agent-node": "3.696.0",
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/core": "^2.5.3",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/hash-node": "^3.0.10",
-        "@smithy/invalid-dependency": "^3.0.10",
-        "@smithy/middleware-content-length": "^3.0.12",
-        "@smithy/middleware-endpoint": "^3.2.3",
-        "@smithy/middleware-retry": "^3.0.27",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.27",
-        "@smithy/util-defaults-mode-node": "^3.0.27",
-        "@smithy/util-endpoints": "^2.1.6",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.699.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
-      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.699.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-node": "3.699.0",
-        "@aws-sdk/middleware-host-header": "3.696.0",
-        "@aws-sdk/middleware-logger": "3.696.0",
-        "@aws-sdk/middleware-recursion-detection": "3.696.0",
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/region-config-resolver": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@aws-sdk/util-user-agent-browser": "3.696.0",
-        "@aws-sdk/util-user-agent-node": "3.696.0",
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/core": "^2.5.3",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/hash-node": "^3.0.10",
-        "@smithy/invalid-dependency": "^3.0.10",
-        "@smithy/middleware-content-length": "^3.0.12",
-        "@smithy/middleware-endpoint": "^3.2.3",
-        "@smithy/middleware-retry": "^3.0.27",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.27",
-        "@smithy/util-defaults-mode-node": "^3.0.27",
-        "@smithy/util-endpoints": "^2.1.6",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
-      "integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.808.0.tgz",
+      "integrity": "sha512-+nTmxJVIPtAarGq9Fd/uU2qU/Ngfb9EntT0/kwXdKKMI0wU9fQNWi10xSTVeqOtzWERbQpOJgBAdta+v3W7cng==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/core": "^2.5.3",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/signature-v4": "^4.2.2",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-middleware": "^3.0.10",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.699.0.tgz",
-      "integrity": "sha512-iuaTnudaBfEET+o444sDwf71Awe6UiZfH+ipUPmswAi2jZDwdFF1nxMKDEKL8/LV5WpXsdKSfwgS0RQeupURew==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.808.0.tgz",
+      "integrity": "sha512-AbsD/qHyQmyZ+CqJNOaGlnwZaXu8HfndfEiLsIJU/dIf9Wbt7ZtsHSAI/x78awxGohDneMZ6c5vuaRGYL7Z04g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.699.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/client-cognito-identity": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
-      "integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.808.0.tgz",
+      "integrity": "sha512-snPRQnwG9PV4kYHQimo1tenf7P974RcdxkHUThzWSxPEV7HpjxTFYNWGlKbOKBhL4AcgeCVeiZ/j+zveF2lEPA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
-      "integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.808.0.tgz",
+      "integrity": "sha512-gNXjlx3BIUeX7QpVqxbjBxG6zm45lC39QvUIo92WzEJd2OTPcR8TU0OTTsgq/lpn2FrKcISj5qXvhWykd41+CA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/smithy-client": "^3.4.4",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-stream": "^3.3.1",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-stream": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
-      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.808.0.tgz",
+      "integrity": "sha512-Y53CW0pCvFQQEvtVFwExCCMbTg+6NOl8b3YOuZVzPmVmDoW7M1JIn9IScesqoGERXL3VoXny6nYTsZj+vfpp7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-env": "3.696.0",
-        "@aws-sdk/credential-provider-http": "3.696.0",
-        "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.699.0",
-        "@aws-sdk/credential-provider-web-identity": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/credential-provider-imds": "^3.2.6",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/shared-ini-file-loader": "^3.1.10",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-env": "3.808.0",
+        "@aws-sdk/credential-provider-http": "3.808.0",
+        "@aws-sdk/credential-provider-process": "3.808.0",
+        "@aws-sdk/credential-provider-sso": "3.808.0",
+        "@aws-sdk/credential-provider-web-identity": "3.808.0",
+        "@aws-sdk/nested-clients": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.699.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
-      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.808.0.tgz",
+      "integrity": "sha512-lASHlXJ6U5Cpnt9Gs+mWaaSmWcEibr1AFGhp+5UNvfyd+UU2Oiwgbo7rYXygmaVDGkbfXEiTkgYtoNOBSddnWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.696.0",
-        "@aws-sdk/credential-provider-http": "3.696.0",
-        "@aws-sdk/credential-provider-ini": "3.699.0",
-        "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.699.0",
-        "@aws-sdk/credential-provider-web-identity": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/credential-provider-imds": "^3.2.6",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/shared-ini-file-loader": "^3.1.10",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/credential-provider-env": "3.808.0",
+        "@aws-sdk/credential-provider-http": "3.808.0",
+        "@aws-sdk/credential-provider-ini": "3.808.0",
+        "@aws-sdk/credential-provider-process": "3.808.0",
+        "@aws-sdk/credential-provider-sso": "3.808.0",
+        "@aws-sdk/credential-provider-web-identity": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
-      "integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.808.0.tgz",
+      "integrity": "sha512-ZLqp+xsQUatoo8pMozcfLwf/pwfXeIk0w3n0Lo/rWBgT3RcdECmmPCRcnkYBqxHQyE66aS9HiJezZUwMYPqh6w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/shared-ini-file-loader": "^3.1.10",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
-      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.808.0.tgz",
+      "integrity": "sha512-gWZByAokHX+aps1+syIW/hbKUBrjE2RpPRd/RGQvrBbVVgwsJzsHKsW0zy1B6mgARPG6IahmSUMjNkBCVsiAgw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.696.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/token-providers": "3.699.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/shared-ini-file-loader": "^3.1.10",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/client-sso": "3.808.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/token-providers": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
-      "integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.808.0.tgz",
+      "integrity": "sha512-SsGa1Gfa05aJM/qYOtHmfg0OKKW6Fl6kyMCcai63jWDVDYy0QSHcesnqRayJolISkdsVK6bqoWoFcPxiopcFcg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/nested-clients": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.696.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.699.0.tgz",
-      "integrity": "sha512-jBjOntl9zN9Nvb0jmbMGRbiTzemDz64ij7W6BDavxBJRZpRoNeN0QCz6RolkCyXnyUJjo5mF2unY2wnv00A+LQ==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.808.0.tgz",
+      "integrity": "sha512-JJvY/gcet+tFw7dGifhTMJ2jfLXCJBR2Tu2rY/ePi+HVUrR//TnWmcm8qGvT1nWiCQ7w9NEhMlJgqKEIM/MkVQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.699.0",
-        "@aws-sdk/client-sso": "3.696.0",
-        "@aws-sdk/client-sts": "3.699.0",
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.699.0",
-        "@aws-sdk/credential-provider-env": "3.696.0",
-        "@aws-sdk/credential-provider-http": "3.696.0",
-        "@aws-sdk/credential-provider-ini": "3.699.0",
-        "@aws-sdk/credential-provider-node": "3.699.0",
-        "@aws-sdk/credential-provider-process": "3.696.0",
-        "@aws-sdk/credential-provider-sso": "3.699.0",
-        "@aws-sdk/credential-provider-web-identity": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/credential-provider-imds": "^3.2.6",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/client-cognito-identity": "3.808.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.808.0",
+        "@aws-sdk/credential-provider-env": "3.808.0",
+        "@aws-sdk/credential-provider-http": "3.808.0",
+        "@aws-sdk/credential-provider-ini": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/credential-provider-process": "3.808.0",
+        "@aws-sdk/credential-provider-sso": "3.808.0",
+        "@aws-sdk/credential-provider-web-identity": "3.808.0",
+        "@aws-sdk/nested-clients": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
-      "integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.804.0.tgz",
+      "integrity": "sha512-bum1hLVBrn2lJCi423Z2fMUYtsbkGI2s4N+2RI2WSjvbaVyMSv/WcejIrjkqiiMR+2Y7m5exgoKeg4/TODLDPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
-      "integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.804.0.tgz",
+      "integrity": "sha512-w/qLwL3iq0KOPQNat0Kb7sKndl9BtceigINwBU7SpkYWX9L/Lem6f8NPEKrC9Tl4wDBht3Yztub4oRTy/horJA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
-      "integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.804.0.tgz",
+      "integrity": "sha512-zqHOrvLRdsUdN/ehYfZ9Tf8svhbiLLz5VaWUz22YndFv6m9qaAcijkpAOlKexsv3nLBMJdSdJ6GUTAeIy3BZzw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
-      "integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.808.0.tgz",
+      "integrity": "sha512-VckV6l5cf/rL3EtgzSHVTTD4mI0gd8UxDDWbKJsxbQ2bpNPDQG2L1wWGLaolTSzjEJ5f3ijDwQrNDbY9l85Mmg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@aws-sdk/util-endpoints": "3.696.0",
-        "@smithy/core": "^2.5.3",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.808.0.tgz",
+      "integrity": "sha512-NparPojwoBul7XPCasy4psFMJbw7Ys4bz8lVB93ljEUD4VV7mM7zwK27Uhz20B8mBFGmFEoAprPsVymJcK9Vcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
-      "integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.808.0.tgz",
+      "integrity": "sha512-9x2QWfphkARZY5OGkl9dJxZlSlYM2l5inFeo2bKntGuwg4A4YUe5h7d5yJ6sZbam9h43eBrkOdumx03DAkQF9A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.10",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.699.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
-      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.808.0.tgz",
+      "integrity": "sha512-PsfKanHmnyO7FxowXqxbLQ+QjURCdSGxyhUiSdZbfvlvme/wqaMyIoMV/i4jppndksoSdPbW2kZXjzOqhQF+ew==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/property-provider": "^3.1.9",
-        "@smithy/shared-ini-file-loader": "^3.1.10",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/nested-clients": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.699.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
-      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.804.0.tgz",
+      "integrity": "sha512-A9qnsy9zQ8G89vrPPlNG9d1d8QcKRGqJKqwyGgS0dclJpwy6d1EWgQLIolKPl6vcFpLoe6avLOLxr+h8ur5wpg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
-      "integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.808.0.tgz",
+      "integrity": "sha512-N6Lic98uc4ADB7fLWlzx+1uVnq04VgVjngZvwHoujcRg9YDhIg9dUDiTzD5VZv13g1BrPYmvYP1HhsildpGV6w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-endpoints": "^2.1.6",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-endpoints": "^3.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -991,29 +989,31 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
-      "integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.804.0.tgz",
+      "integrity": "sha512-KfW6T6nQHHM/vZBBdGn6fMyG/MgX5lq82TDdX4HRQRRuHKLgBWGpKXqqvBwqIaCdXwWHgDrg2VQups6GqOWW2A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.696.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
-      "integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.808.0.tgz",
+      "integrity": "sha512-5UmB6u7RBSinXZAVP2iDgqyeVA/odO2SLEcrXaeTCw8ICXEoqF0K+GL36T4iDbzCBOAIugOZ6OcQX5vH3ck5UA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.696.0",
-        "@aws-sdk/types": "3.696.0",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/types": "^3.7.1",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1035,15 +1035,15 @@
       }
     },
     "node_modules/@aws/amazon-location-utilities-auth-helper": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@aws/amazon-location-utilities-auth-helper/-/amazon-location-utilities-auth-helper-1.2.1.tgz",
-      "integrity": "sha512-MS068lHZZ1bP4V2X1+9joAzsONW8iUoZOg3DGriNFpaomwAQ5Aeg2cFIFxXtnHq5FxVRkPuRdnn32Wc4pUCZUg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/amazon-location-utilities-auth-helper/-/amazon-location-utilities-auth-helper-1.2.2.tgz",
+      "integrity": "sha512-bEHQrN+dGeVuZXd1Tx6eg0HQFCd08CXmWhuCHrc/jnE777UJvKnPxSavBMzkMYP0YKGg4zbRzeO045OnKPkJYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-sdk/credential-providers": "^3.682.0",
-        "@aws-sdk/types": "^3.609.0",
-        "@smithy/util-hex-encoding": "^2.2.0"
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@aws-sdk/types": "^3.804.0",
+        "@smithy/util-hex-encoding": "^4.0.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -4836,168 +4836,187 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
-      "integrity": "sha512-+3DOBcUn5/rVjlxGvUPKc416SExarAQ+Qe0bqk30YSUjbepwpS7QN0cyKUSifvLJhdMZ0WPzPP5ymut0oonrpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+      "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.12.tgz",
-      "integrity": "sha512-YAJP9UJFZRZ8N+UruTeq78zkdjUHmzsY62J4qKWZ4SXB4QXJ/+680EfXXgkYA2xj77ooMqtUY9m406zGNqwivQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.2.tgz",
+      "integrity": "sha512-7r6mZGwb5LmLJ+zPtkLoznf2EtwEuSWdtid10pjGl/7HefCE4mueOkrfki8JCUm99W6UfP47/r3tbxx9CfBN5A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.4.tgz",
-      "integrity": "sha512-iFh2Ymn2sCziBRLPuOOxRPkuCx/2gBdXtBGuCUFLUe6bWYjKnhHyIPqGeNkLZ5Aco/5GjebRTBFiWID3sDbrKw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.2.tgz",
+      "integrity": "sha512-GlLv+syoWolhtjX12XplL9BXBu10cjjD8iQC69fiKTrVNOB3Fjt8CVI9ccm6G3bLbMNe1gzrLD7yyMkYo4hchw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-stream": "^3.3.1",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/middleware-serde": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.7.tgz",
-      "integrity": "sha512-cEfbau+rrWF8ylkmmVAObOmjbTIzKyUC5TkBL58SbLywD0RCBC4JAUKbmtSm2w5KUJNRPGgpGFMvE2FKnuNlWQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.4.tgz",
+      "integrity": "sha512-jN6M6zaGVyB8FmNGG+xOPQB4N89M1x97MMdMnm1ESjljLS3Qju/IegQizKujaNcy2vXAvrz0en8bobe6E55FEA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/property-provider": "^3.1.10",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
-      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+      "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/querystring-builder": "^3.0.10",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-base64": "^3.0.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/querystring-builder": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.10.tgz",
-      "integrity": "sha512-3zWGWCHI+FlJ5WJwx73Mw2llYR8aflVyZN5JhoqLxbdPZi6UyKSdCeXAWJw9ja22m6S6Tzz1KZ+kAaSwvydi0g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+      "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.10.tgz",
-      "integrity": "sha512-Lp2L65vFi+cj0vFMu2obpPW69DU+6O5g3086lmI4XcnRCG8PxvpWC7XyaVwJCxsZFzueHjXnrOH/E0pl0zikfA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+      "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
@@ -5012,347 +5031,369 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.12.tgz",
-      "integrity": "sha512-1mDEXqzM20yywaMDuf5o9ue8OkJ373lSPbaSjyEvkWdqELhFMyNNgKGWL/rCSf4KME8B+HlHKuR8u9kRj8HzEQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+      "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.4.tgz",
-      "integrity": "sha512-TybiW2LA3kYVd3e+lWhINVu1o26KJbBwOpADnf0L4x/35vLVica77XVR5hvV9+kWeTGeSJ3IHTcYxbRxlbwhsg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.5.tgz",
+      "integrity": "sha512-WlpC9KVkajQf7RaGwi3n6lhHZzYTgm2PyX/2JjcwSHG417gFloNmYqN8rzDRXjT527/ZxZuvCsqq1gWZPW8lag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.5.4",
-        "@smithy/middleware-serde": "^3.0.10",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/shared-ini-file-loader": "^3.1.11",
-        "@smithy/types": "^3.7.1",
-        "@smithy/url-parser": "^3.0.10",
-        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/core": "^3.3.2",
+        "@smithy/middleware-serde": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.28.tgz",
-      "integrity": "sha512-vK2eDfvIXG1U64FEUhYxoZ1JSj4XFbYWkK36iz02i3pFwWiDz1Q7jKhGTBCwx/7KqJNk4VS7d7cDLXFOvP7M+g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.6.tgz",
+      "integrity": "sha512-bl8q95nvCf7d22spxsBfs2giUDFf7prWLAxF5tmfgGBYHbUNW+OfnwMnabC15GMLA2AoE4HOtQR18a59lx6Blw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/service-error-classification": "^3.0.10",
-        "@smithy/smithy-client": "^3.4.5",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-retry": "^3.0.10",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/service-error-classification": "^4.0.3",
+        "@smithy/smithy-client": "^4.2.5",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
-      "integrity": "sha512-MnAuhh+dD14F428ubSJuRnmRsfOpxSzvRhaGVTvd/lrUDE3kxzCCmH8lnVTvoNQnV2BbJ4c15QwZ3UdQBtFNZA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.4.tgz",
+      "integrity": "sha512-CaLvBtz+Xgs7eOwoinTXhZ02/9u8b28RT8lQAaDh7Q59nygeYYp1UiJjwl6zsay+lp0qVT/S7qLVI5RgcxjyfQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.10.tgz",
-      "integrity": "sha512-grCHyoiARDBBGPyw2BeicpjgpsDFWZZxptbVKb3CRd/ZA15F/T6rZjCCuBUjJwdck1nwUuIxYtsS4H9DDpbP5w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+      "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.11.tgz",
-      "integrity": "sha512-URq3gT3RpDikh/8MBJUB+QGZzfS7Bm6TQTqoh4CqE8NBuyPkWa5eUXj0XFcFfeZVgg3WMh1u19iaXn8FvvXxZw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.1.tgz",
+      "integrity": "sha512-1slS5jf5icHETwl5hxEVBj+mh6B+LbVW4yRINsGtUKH+nxM5Pw2H59+qf+JqYFCHp9jssG4vX81f5WKnjMN3Vw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.10",
-        "@smithy/shared-ini-file-loader": "^3.1.11",
-        "@smithy/types": "^3.7.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.1.tgz",
-      "integrity": "sha512-fr+UAOMGWh6bn4YSEezBCpJn9Ukp9oR4D32sCjCo7U81evE11YePOQ58ogzyfgmjIO79YeOdfXXqr0jyhPQeMg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+      "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.8",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/querystring-builder": "^3.0.10",
-        "@smithy/types": "^3.7.1",
+        "@smithy/abort-controller": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/querystring-builder": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.10.tgz",
-      "integrity": "sha512-n1MJZGTorTH2DvyTVj+3wXnd4CzjJxyXeOgnTlgNVFxaaMeT4OteEp4QrzF8p9ee2yg42nvyVK6R/awLCakjeQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+      "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.7.tgz",
-      "integrity": "sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+      "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.10.tgz",
-      "integrity": "sha512-nT9CQF3EIJtIUepXQuBFb8dxJi3WVZS3XfuDksxSCSn+/CzZowRLdhDn+2acbBv8R6eaJqPupoI/aRFIImNVPQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+      "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.10.tgz",
-      "integrity": "sha512-Oa0XDcpo9SmjhiDD9ua2UyM3uU01ZTuIrNdZvzwUTykW1PM8o2yJvMh1Do1rY5sUQg4NDV70dMi0JhDx4GyxuQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+      "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.10.tgz",
-      "integrity": "sha512-zHe642KCqDxXLuhs6xmHVgRwy078RfqxP2wRDpIyiF8EmsWXptMwnMwbVa50lw+WOGNrYm9zbaEg0oDe3PTtvQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.3.tgz",
+      "integrity": "sha512-FTbcajmltovWMjj3tksDQdD23b2w6gH+A0DYA1Yz3iSpjDj8fmkwy62UnXcWMy4d5YoMoSyLFHMfkEVEzbiN8Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1"
+        "@smithy/types": "^4.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.11.tgz",
-      "integrity": "sha512-AUdrIZHFtUgmfSN4Gq9nHu3IkHMa1YDcN+s061Nfm+6pQ0mJy85YQDB0tZBCmls0Vuj22pLwDPmL92+Hvfwwlg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+      "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.3.tgz",
-      "integrity": "sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.0.tgz",
+      "integrity": "sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.10",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.5.tgz",
-      "integrity": "sha512-k0sybYT9zlP79sIKd1XGm4TmK0AS1nA2bzDHXx7m0nGi3RQ8dxxQUs4CPkSmQTKAo+KF9aINU3KzpGIpV7UoMw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.5.tgz",
+      "integrity": "sha512-T3gA/TShe52Ln0ywWGVoDiqRvaxqvrU0CKRRmzT71/I1rRBD8mY85rvMMME6vw5RpBLJC9ADmXSLmpohF7RRhA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.5.4",
-        "@smithy/middleware-endpoint": "^3.2.4",
-        "@smithy/middleware-stack": "^3.0.10",
-        "@smithy/protocol-http": "^4.1.7",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-stream": "^3.3.1",
+        "@smithy/core": "^3.3.2",
+        "@smithy/middleware-endpoint": "^4.1.5",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-stream": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.1.tgz",
-      "integrity": "sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.10.tgz",
-      "integrity": "sha512-j90NUalTSBR2NaZTuruEgavSdh8MLirf58LoGSk4AtQfyIymogIhgnGUU2Mga2bkMkpSoC9gxb74xBXL5afKAQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+      "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.10",
-        "@smithy/types": "^3.7.1",
+        "@smithy/querystring-parser": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
@@ -5368,170 +5409,171 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.28.tgz",
-      "integrity": "sha512-6bzwAbZpHRFVJsOztmov5PGDmJYsbNSoIEfHSJJyFLzfBGCCChiO3od9k7E/TLgrCsIifdAbB9nqbVbyE7wRUw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.13.tgz",
+      "integrity": "sha512-HCLfXAyTEpVWLuyxDABg8UQukeRwChL1UErpSQ4KJK2ZoadmXuQY68pTL9KcuEtasTkIjnzyLUL9vhLdJ3VFHQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.10",
-        "@smithy/smithy-client": "^3.4.5",
-        "@smithy/types": "^3.7.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/smithy-client": "^4.2.5",
+        "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.28.tgz",
-      "integrity": "sha512-78ENJDorV1CjOQselGmm3+z7Yqjj5HWCbjzh0Ixuq736dh1oEnD9sAttSBNSLlpZsX8VQnmERqA2fEFlmqWn8w==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.13.tgz",
+      "integrity": "sha512-lu8E2RyzKzzFbNu4ICmY/2HltMZlJxMNg3saJ+r8I9vWbWbwdX7GOWUJdP4fbjEOm6aa52mnnd+uIRrT3dNEyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.12",
-        "@smithy/credential-provider-imds": "^3.2.7",
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/property-provider": "^3.1.10",
-        "@smithy/smithy-client": "^3.4.5",
-        "@smithy/types": "^3.7.1",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/credential-provider-imds": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/smithy-client": "^4.2.5",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.6.tgz",
-      "integrity": "sha512-mFV1t3ndBh0yZOJgWxO9J/4cHZVn5UG1D8DeCc6/echfNkeEJWu9LD7mgGH5fHrEdR7LDoWw7PQO6QiGpHXhgA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.4.tgz",
+      "integrity": "sha512-VfFATC1bmZLV2858B/O1NpMcL32wYo8DPPhHxYxDCodDl3f3mSZ5oJheW1IF91A0EeAADz2WsakM/hGGPGNKLg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.11",
-        "@smithy/types": "^3.7.1",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
-      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.10.tgz",
-      "integrity": "sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+      "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.7.1",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.10.tgz",
-      "integrity": "sha512-1l4qatFp4PiU6j7UsbasUHL2VU023NRB/gfaa1M0rDqVrRN4g3mCArLRyH3OuktApA4ye+yjWQHjdziunw2eWA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.3.tgz",
+      "integrity": "sha512-DPuYjZQDXmKr/sNvy9Spu8R/ESa2e22wXZzSAY6NkjOLj6spbIje/Aq8rT97iUMdDj0qHMRIe+bTxvlU74d9Ng==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.10",
-        "@smithy/types": "^3.7.1",
+        "@smithy/service-error-classification": "^4.0.3",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.1.tgz",
-      "integrity": "sha512-Ff68R5lJh2zj+AUTvbAU/4yx+6QPRzg7+pI7M1FbtQHcRIp7xvguxVsQBKyB3fwiOwhAKu0lnNyYBaQfSW6TNw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+      "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^4.1.1",
-        "@smithy/node-http-handler": "^3.3.1",
-        "@smithy/types": "^3.7.1",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
@@ -10549,7 +10591,8 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -11863,6 +11906,28 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -17354,9 +17419,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/subtag": {
       "version": "0.5.0",
@@ -17934,6 +18006,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -79,10 +79,11 @@
     "!(*.{js,ts})": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@aws-sdk/client-geo-places": "^3.699.0",
-    "@aws-sdk/client-location": "^3.699.0",
+    "@aws-sdk/client-geo-places": "^3.808.0",
+    "@aws-sdk/client-geo-routes": "3.808.0",
+    "@aws-sdk/client-location": "^3.808.0",
     "@aws/amazon-location-for-maplibre-gl-geocoder": "^2.0.2",
-    "@aws/amazon-location-utilities-auth-helper": "^1.2.1",
+    "@aws/amazon-location-utilities-auth-helper": "^1.2.2",
     "@turf/turf": "^7.1.0",
     "libphonenumber-js": "^1.11.16",
     "maplibre-gl": "^5.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 import { withAPIKey } from "@aws/amazon-location-utilities-auth-helper";
 import { LocationClient } from "@aws-sdk/client-location";
 import { GeoPlacesClient } from "@aws-sdk/client-geo-places";
+import { GeoRoutesClient } from "@aws-sdk/client-geo-routes";
 
 import {
   MigrationDirectionsRenderer,
@@ -99,7 +100,13 @@ const migrationInit = async function () {
     ...authHelperV1.getClientConfig(), // Configures the client to use API keys when making supported requests
   });
 
-  const client = new GeoPlacesClient({
+  const placesClient = new GeoPlacesClient({
+    region: region, // Region containing Amazon Location resource
+    customUserAgent: `migration-sdk-${PACKAGE_VERSION}`, // Append tag with SDK version to the default user agent
+    ...authHelper.getClientConfig(), // Configures the client to use API keys when making supported requests
+  });
+
+  const routesClient = new GeoRoutesClient({
     region: region, // Region containing Amazon Location resource
     customUserAgent: `migration-sdk-${PACKAGE_VERSION}`, // Append tag with SDK version to the default user agent
     ...authHelper.getClientConfig(), // Configures the client to use API keys when making supported requests
@@ -107,15 +114,14 @@ const migrationInit = async function () {
 
   // Pass our location client, and optionally place index and route calculator names
   // to our migration services
-  MigrationAutocomplete.prototype._client = client;
-  MigrationAutocompleteService.prototype._client = client;
+  MigrationAutocomplete.prototype._client = placesClient;
+  MigrationAutocompleteService.prototype._client = placesClient;
   MigrationGeocoder.prototype._client = clientV1;
   MigrationGeocoder.prototype._placeIndexName = placeIndexName;
-  MigrationPlace._client = client;
-  MigrationPlacesService.prototype._client = client;
-  MigrationSearchBox.prototype._client = client;
-  MigrationDirectionsService.prototype._client = clientV1;
-  MigrationDirectionsService.prototype._routeCalculatorName = routeCalculatorName;
+  MigrationPlace._client = placesClient;
+  MigrationPlacesService.prototype._client = placesClient;
+  MigrationSearchBox.prototype._client = placesClient;
+  MigrationDirectionsService.prototype._client = routesClient;
   MigrationDistanceMatrixService.prototype._client = clientV1;
   MigrationDistanceMatrixService.prototype._routeCalculatorName = routeCalculatorName;
 

--- a/test/directions.test.ts
+++ b/test/directions.test.ts
@@ -55,59 +55,7 @@ const testAnotherCoolPlaceLocation = new MigrationLatLng(7, 8);
 
 const mockedClientSendV1 = jest.fn((command) => {
   return new Promise((resolve, reject) => {
-    if (command instanceof CalculateRouteCommand) {
-      if (JSON.stringify(command.input.DestinationPosition) == JSON.stringify(clientErrorDestinationPosition)) {
-        // Return an empty object that will throw an error
-        resolve({});
-      } else {
-        const startPosition = command.input.DeparturePosition as number[];
-        const endPosition = command.input.DestinationPosition as number[];
-
-        resolve({
-          Legs: [
-            {
-              Distance: 9001,
-              DurationSeconds: 12032,
-              EndPosition: endPosition,
-              Geometry: {
-                LineString: [
-                  [0, 0],
-                  [1, 1],
-                  [2, 2],
-                ],
-              },
-              StartPosition: startPosition,
-              Steps: [
-                {
-                  Distance: 3,
-                  DurationSeconds: 5,
-                  EndPosition: [3, 4],
-                  StartPosition: [1, 2],
-                },
-                {
-                  Distance: 4,
-                  DurationSeconds: 6,
-                  EndPosition: [6, 7],
-                  StartPosition: [3, 4],
-                },
-                {
-                  Distance: 10,
-                  DurationSeconds: 7,
-                  EndPosition: [20, 21],
-                  StartPosition: [6, 7],
-                },
-              ],
-            },
-          ],
-          Summary: {
-            Distance: 9001,
-            DistanceUnit: "Kilometers",
-            DurationSeconds: 1337,
-            RouteBBox: startPosition.concat(endPosition),
-          },
-        });
-      }
-    } else if (command instanceof CalculateRouteMatrixCommand) {
+    if (command instanceof CalculateRouteMatrixCommand) {
       // checks if DestinationPositions array contains clientErrorDestinationPosition
       if (
         command.input.DestinationPositions?.some(
@@ -136,9 +84,9 @@ jest.mock("@aws-sdk/client-location", () => ({
     };
   }),
 }));
-import { LocationClient, CalculateRouteCommand, CalculateRouteMatrixCommand } from "@aws-sdk/client-location";
+import { LocationClient, CalculateRouteMatrixCommand } from "@aws-sdk/client-location";
 
-const mockedClientSend = jest.fn((command) => {
+const mockedPlacesClientSend = jest.fn((command) => {
   return new Promise((resolve, reject) => {
     if (command instanceof GetPlaceCommand) {
       if (command.input.PlaceId === undefined || command.input.PlaceId === clientErrorPlaceId) {
@@ -258,15 +206,315 @@ jest.mock("@aws-sdk/client-geo-places", () => ({
   ...jest.requireActual("@aws-sdk/client-geo-places"),
   GeoPlacesClient: jest.fn().mockImplementation(() => {
     return {
-      send: mockedClientSend,
+      send: mockedPlacesClientSend,
     };
   }),
 }));
 import { GeoPlacesClient, GetPlaceCommand, SearchTextCommand } from "@aws-sdk/client-geo-places";
 
+const testDeparturePosition = [-97.7335401, 30.2870699];
+const testArrivalPosition = [-97.7385452, 30.3134151];
+const testRouteBounds = new MigrationLatLngBounds({
+  east: -97.7298,
+  north: 30.31381,
+  west: -97.738545,
+  south: 30.28707,
+});
+const mockedRoutesClientSend = jest.fn((command) => {
+  return new Promise((resolve, reject) => {
+    if (command instanceof CalculateRoutesCommand) {
+      if (JSON.stringify(command.input.Destination) == JSON.stringify(clientErrorDestinationPosition)) {
+        // Return an empty object that will throw an error
+        resolve({});
+      } else {
+        resolve({
+          LegGeometryFormat: "Simple",
+          Notices: [],
+          Routes: [
+            {
+              Legs: [
+                {
+                  Geometry: {
+                    LineString: [
+                      [-97.73354, 30.28707],
+                      [-97.73355, 30.28715],
+                      [-97.73356, 30.28735],
+                      [-97.73361, 30.28752],
+                      [-97.7337, 30.28766],
+                      [-97.73379, 30.28778],
+                      [-97.73396, 30.28797],
+                      [-97.73434, 30.28841],
+                      [-97.73445, 30.28859],
+                      [-97.7345, 30.2887],
+                      [-97.73453, 30.28878],
+                      [-97.73458, 30.28896],
+                      [-97.73461, 30.28907],
+                      [-97.73461, 30.28931],
+                      [-97.73457, 30.28962],
+                      [-97.73454, 30.28976],
+                      [-97.73449, 30.29005],
+                      [-97.73449, 30.29019],
+                      [-97.73452, 30.29043],
+                      [-97.73446, 30.29054],
+                      [-97.73446, 30.29061],
+                      [-97.73464, 30.29112],
+                      [-97.73454, 30.29126],
+                      [-97.73444, 30.29142],
+                      [-97.73424, 30.29174],
+                      [-97.73413, 30.29191],
+                      [-97.73401, 30.2921],
+                      [-97.73392, 30.29224],
+                      [-97.73367, 30.29266],
+                      [-97.73333, 30.29318],
+                      [-97.73291, 30.29383],
+                      [-97.73275, 30.29408],
+                      [-97.73247, 30.29453],
+                      [-97.73183, 30.29553],
+                      [-97.73149, 30.29606],
+                      [-97.73122, 30.29649],
+                      [-97.73118, 30.29655],
+                      [-97.73095, 30.29691],
+                      [-97.73055, 30.29754],
+                      [-97.7304, 30.29778],
+                      [-97.73, 30.2984],
+                      [-97.7298, 30.29872],
+                      [-97.73016, 30.2989],
+                      [-97.73075, 30.2992],
+                      [-97.73093, 30.29929],
+                      [-97.73154, 30.29957],
+                      [-97.7321, 30.29984],
+                      [-97.73268, 30.30012],
+                      [-97.73312, 30.30033],
+                      [-97.73343, 30.30048],
+                      [-97.73357, 30.30055],
+                      [-97.73392, 30.30071],
+                      [-97.73415, 30.30082],
+                      [-97.73441, 30.30094],
+                      [-97.73454, 30.301],
+                      [-97.73469, 30.30107],
+                      [-97.73492, 30.30118],
+                      [-97.73511, 30.30127],
+                      [-97.73524, 30.30133],
+                      [-97.73553, 30.30147],
+                      [-97.73557, 30.30149],
+                      [-97.73581, 30.30161],
+                      [-97.73631, 30.30185],
+                      [-97.73708, 30.30221],
+                      [-97.73744, 30.30238],
+                      [-97.73763, 30.30248],
+                      [-97.73781, 30.30257],
+                      [-97.73791, 30.30262],
+                      [-97.73816, 30.30275],
+                      [-97.73796, 30.30306],
+                      [-97.73789, 30.30318],
+                      [-97.73784, 30.30325],
+                      [-97.73774, 30.30342],
+                      [-97.73768, 30.30351],
+                      [-97.73752, 30.30376],
+                      [-97.73734, 30.30406],
+                      [-97.73729, 30.30414],
+                      [-97.73722, 30.30425],
+                      [-97.73701, 30.30457],
+                      [-97.73688, 30.30476],
+                      [-97.73668, 30.30505],
+                      [-97.73654, 30.30525],
+                      [-97.7364, 30.30549],
+                      [-97.73634, 30.30559],
+                      [-97.73609, 30.30599],
+                      [-97.73584, 30.30638],
+                      [-97.73575, 30.30652],
+                      [-97.73561, 30.30674],
+                      [-97.73528, 30.30725],
+                      [-97.73514, 30.30749],
+                      [-97.73471, 30.30816],
+                      [-97.73461, 30.30831],
+                      [-97.73444, 30.30864],
+                      [-97.73421, 30.30899],
+                      [-97.73402, 30.30928],
+                      [-97.73371, 30.30976],
+                      [-97.73325, 30.31045],
+                      [-97.73299, 30.31085],
+                      [-97.73352, 30.31116],
+                      [-97.73372, 30.31128],
+                      [-97.7339, 30.31138],
+                      [-97.73529, 30.31221],
+                      [-97.73537, 30.31225],
+                      [-97.73596, 30.31259],
+                      [-97.73624, 30.31275],
+                      [-97.7368, 30.31305],
+                      [-97.73702, 30.31317],
+                      [-97.73759, 30.31348],
+                      [-97.73799, 30.31367],
+                      [-97.7381, 30.31372],
+                      [-97.73829, 30.31381],
+                      [-97.73841, 30.31362],
+                      [-97.738545, 30.313415],
+                    ],
+                  },
+                  Language: "en-us",
+                  TravelMode: "Car",
+                  Type: "Vehicle",
+                  VehicleLegDetails: {
+                    Arrival: {
+                      Place: {
+                        OriginalPosition: [-97.73835, 30.31332],
+                        Position: testArrivalPosition,
+                      },
+                    },
+                    Departure: {
+                      Place: {
+                        OriginalPosition: [-97.7335401, 30.2870299],
+                        Position: testDeparturePosition,
+                      },
+                    },
+                    Incidents: [],
+                    Notices: [],
+                    PassThroughWaypoints: [],
+                    Spans: [],
+                    Summary: {
+                      Overview: {
+                        BestCaseDuration: 423,
+                        Distance: 4047,
+                        Duration: 423,
+                        TypicalDuration: 423,
+                      },
+                      TravelOnly: {
+                        BestCaseDuration: 423,
+                        Duration: 423,
+                        TypicalDuration: 423,
+                      },
+                    },
+                    TollSystems: [],
+                    Tolls: [],
+                    TravelSteps: [
+                      {
+                        Distance: 403,
+                        Duration: 74,
+                        ExitNumber: [],
+                        GeometryOffset: 0,
+                        Instruction: "Head north on San Jacinto Blvd. Go for 403 m.",
+                        Type: "Depart",
+                      },
+                      {
+                        Distance: 1044,
+                        Duration: 112,
+                        ExitNumber: [],
+                        GeometryOffset: 18,
+                        Instruction: "Turn right onto Duval St. Go for 1.0 km.",
+                        TurnStepDetails: {
+                          Intersection: [],
+                          SteeringDirection: "Right",
+                          TurnIntensity: "Typical",
+                        },
+                        Type: "Turn",
+                      },
+                      {
+                        Distance: 916,
+                        Duration: 77,
+                        ExitNumber: [],
+                        GeometryOffset: 41,
+                        Instruction: "Turn left onto E 38th St. Go for 916 m.",
+                        TurnStepDetails: {
+                          Intersection: [],
+                          SteeringDirection: "Left",
+                          TurnIntensity: "Typical",
+                        },
+                        Type: "Turn",
+                      },
+                      {
+                        Distance: 1029,
+                        Duration: 80,
+                        ExitNumber: [],
+                        GeometryOffset: 68,
+                        Instruction: "Turn right onto Guadalupe St. Go for 1.0 km.",
+                        TurnStepDetails: {
+                          Intersection: [],
+                          SteeringDirection: "Right",
+                          TurnIntensity: "Typical",
+                        },
+                        Type: "Turn",
+                      },
+                      {
+                        Distance: 605,
+                        Duration: 62,
+                        ExitNumber: [],
+                        GeometryOffset: 97,
+                        Instruction: "Turn left onto W 45th St. Go for 605 m.",
+                        TurnStepDetails: {
+                          Intersection: [],
+                          SteeringDirection: "Left",
+                          TurnIntensity: "Typical",
+                        },
+                        Type: "Turn",
+                      },
+                      {
+                        Distance: 50,
+                        Duration: 18,
+                        ExitNumber: [],
+                        GeometryOffset: 110,
+                        Instruction: "Turn left. Go for 50 m.",
+                        TurnStepDetails: {
+                          Intersection: [],
+                          SteeringDirection: "Left",
+                          TurnIntensity: "Typical",
+                        },
+                        Type: "Turn",
+                      },
+                      {
+                        Distance: 0,
+                        Duration: 0,
+                        ExitNumber: [],
+                        GeometryOffset: 112,
+                        Instruction: "Arrive at your destination on the left.",
+                        Type: "Arrive",
+                      },
+                    ],
+                    TruckRoadTypes: [],
+                    Zones: [],
+                  },
+                },
+              ],
+              MajorRoadLabels: [
+                {
+                  RoadName: {
+                    Language: "en",
+                    Value: "Guadalupe St",
+                  },
+                },
+                {
+                  RoadName: {
+                    Language: "en",
+                    Value: "Duval St",
+                  },
+                },
+              ],
+              Summary: {
+                Distance: 4047,
+                Duration: 423,
+              },
+            },
+          ],
+        });
+      }
+    } else {
+      reject();
+    }
+  });
+});
+
+jest.mock("@aws-sdk/client-geo-routes", () => ({
+  ...jest.requireActual("@aws-sdk/client-geo-routes"),
+  GeoRoutesClient: jest.fn().mockImplementation(() => {
+    return {
+      send: mockedRoutesClientSend,
+    };
+  }),
+}));
+import { GeoRoutesClient, CalculateRoutesCommand, CalculateRoutesRequest } from "@aws-sdk/client-geo-routes";
+
 const directionsService = new MigrationDirectionsService();
 const distanceMatrixService = new MigrationDistanceMatrixService();
-directionsService._client = new LocationClient();
+directionsService._client = new GeoRoutesClient();
 distanceMatrixService._client = new LocationClient();
 
 // The DirectionsService and DistanceMatrixService also uses the PlacesService in cases where the route is specified with a query string
@@ -958,8 +1206,8 @@ test("should get new directions in handler when directions_changed event", (done
 });
 
 test("should return route with origin as LatLng and destination as LatLng", (done) => {
-  const origin = new MigrationLatLng(1, 2);
-  const destination = new MigrationLatLng(20, 21);
+  const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+  const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
 
   const request = {
     origin: origin,
@@ -969,9 +1217,9 @@ test("should return route with origin as LatLng and destination as LatLng", (don
 
   directionsService.route(request).then((response) => {
     // Since origin and destination are both specified as parseable values, the only mocked
-    // LocationClient call should be the CalculateRouteCommand
-    expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+    // GeoPlacesClient call should be the CalculateRoutesCommand
+    expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
 
     const routes = response.routes;
 
@@ -980,7 +1228,7 @@ test("should return route with origin as LatLng and destination as LatLng", (don
     const route = routes[0];
 
     const bounds = route.bounds;
-    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
+    expect(bounds.equals(testRouteBounds)).toStrictEqual(true);
 
     const legs = route.legs;
 
@@ -988,7 +1236,7 @@ test("should return route with origin as LatLng and destination as LatLng", (don
 
     const leg = legs[0];
 
-    expect(leg.steps.length).toStrictEqual(3);
+    expect(leg.steps.length).toStrictEqual(7);
     expect(leg.start_location.equals(origin)).toStrictEqual(true);
     expect(leg.end_location.equals(destination)).toStrictEqual(true);
 
@@ -997,8 +1245,8 @@ test("should return route with origin as LatLng and destination as LatLng", (don
 });
 
 test("should return route with origin as LatLng and destination as Place.location", (done) => {
-  const origin = new MigrationLatLng(1, 2);
-  const destination = new MigrationLatLng(20, 21);
+  const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+  const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
 
   const request = {
     origin: origin,
@@ -1010,26 +1258,20 @@ test("should return route with origin as LatLng and destination as Place.locatio
 
   directionsService.route(request).then((response) => {
     // Since origin and destination are both specified as parseable values, the only mocked
-    // LocationClient call should be the CalculateRouteCommand
-    expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+    // GeoPlacesClient call should be the CalculateRoutesCommand
+    expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
 
     const routes = response.routes;
-
     expect(routes.length).toStrictEqual(1);
-
-    const route = routes[0];
-
-    const bounds = route.bounds;
-    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
 
     done();
   });
 });
 
 test("should return route with origin as Place.location and destination as LatLng", (done) => {
-  const origin = new MigrationLatLng(1, 2);
-  const destination = new MigrationLatLng(20, 21);
+  const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+  const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
 
   const request = {
     origin: {
@@ -1041,26 +1283,20 @@ test("should return route with origin as Place.location and destination as LatLn
 
   directionsService.route(request).then((response) => {
     // Since origin and destination are both specified as parseable values, the only mocked
-    // LocationClient call should be the CalculateRouteCommand
-    expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+    // GeoPlacesClient call should be the CalculateRoutesCommand
+    expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
 
     const routes = response.routes;
-
     expect(routes.length).toStrictEqual(1);
-
-    const route = routes[0];
-
-    const bounds = route.bounds;
-    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
 
     done();
   });
 });
 
 test("should return route with origin as Place.location and destination as Place.location", (done) => {
-  const origin = new MigrationLatLng(1, 2);
-  const destination = new MigrationLatLng(20, 21);
+  const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+  const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
 
   const request = {
     origin: {
@@ -1074,18 +1310,12 @@ test("should return route with origin as Place.location and destination as Place
 
   directionsService.route(request).then((response) => {
     // Since origin and destination are both specified as parseable values, the only mocked
-    // LocationClient call should be the CalculateRouteCommand
-    expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+    // GeoPlacesClient call should be the CalculateRoutesCommand
+    expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
 
     const routes = response.routes;
-
     expect(routes.length).toStrictEqual(1);
-
-    const route = routes[0];
-
-    const bounds = route.bounds;
-    expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
 
     done();
   });
@@ -1103,22 +1333,14 @@ test("should return route with origin as string and destination as Place.query",
   directionsService.route(request).then((response) => {
     // Since both origin and destination were query inputs, these will both trigger a
     // findPlaceFromQuery request to retrieve the location geometry, so there
-    // will be a total of 3 mocked LocationClient.send calls (2 for places, 1 for routes)
-    expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
-    expect(mockedClientSend).toHaveBeenCalledTimes(2);
-    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
+    // will be a total of 3 mocked send calls (2 for places, 1 for routes)
+    expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    expect(mockedPlacesClientSend).toHaveBeenCalledTimes(2);
+    expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
 
     const routes = response.routes;
-
     expect(routes.length).toStrictEqual(1);
-
-    const route = routes[0];
-
-    const bounds = route.bounds;
-    expect(bounds.equals(new MigrationLatLngBounds(testCoolPlaceLocation, testAnotherCoolPlaceLocation))).toStrictEqual(
-      true,
-    );
 
     done();
   });
@@ -1138,12 +1360,12 @@ test("should return route with origin as Place.placeId and destination as Place.
   directionsService.route(request).then((response) => {
     // Since origin was a placeId and destination was a query input, these will trigger a
     // getDetails and findPlaceFromQuery request (respectively) to retrieve the location geometry,
-    // so there will be a total of 3 mocked LocationClient.send calls (2 for places, 1 for routes)
-    expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSend).toHaveBeenCalledTimes(2);
-    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
-    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
-    expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+    // so there will be a total of 3 mocked send calls (2 for places, 1 for routes)
+    expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    expect(mockedPlacesClientSend).toHaveBeenCalledTimes(2);
+    expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
+    expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
 
     const geocodedWaypoints = response.geocoded_waypoints;
     const routes = response.routes;
@@ -1151,11 +1373,7 @@ test("should return route with origin as Place.placeId and destination as Place.
     expect(routes.length).toStrictEqual(1);
 
     const route = routes[0];
-    const bounds = route.bounds;
     const legs = route.legs;
-    expect(bounds.equals(new MigrationLatLngBounds(testCoolPlaceLocation, testAnotherCoolPlaceLocation))).toStrictEqual(
-      true,
-    );
     expect(legs.length).toStrictEqual(1);
 
     const leg = legs[0];
@@ -1167,26 +1385,31 @@ test("should return route with origin as Place.placeId and destination as Place.
     const start_location = leg.start_location;
     const end_location = leg.end_location;
     expect(distance).toStrictEqual({
-      text: "9001 km",
-      value: 9001000,
+      text: "4047 km",
+      value: 4047000,
     });
-    expect(steps.length).toStrictEqual(3);
+    expect(steps.length).toStrictEqual(7);
     expect(duration).toStrictEqual({
-      text: "3 hours 21 mins",
-      value: 12032,
+      text: "8 mins",
+      value: 423,
     });
+
     expect(start_address).toStrictEqual("cool place, austin, tx");
     expect(end_address).toStrictEqual("another cool place, austin, tx");
-    expect(start_location.equals(new MigrationLatLng(testCoolPlaceLocation))).toStrictEqual(true);
-    expect(end_location.equals(new MigrationLatLng(testAnotherCoolPlaceLocation))).toStrictEqual(true);
+    expect(
+      start_location.equals(new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0])),
+    ).toStrictEqual(true);
+    expect(end_location.equals(new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]))).toStrictEqual(
+      true,
+    );
 
     done();
   });
 });
 
 test("should return route with origin as LatLng and destination as LatLng with callback specified", (done) => {
-  const origin = new MigrationLatLng(1, 2);
-  const destination = new MigrationLatLng(20, 21);
+  const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+  const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
 
   const request = {
     origin: origin,
@@ -1197,26 +1420,21 @@ test("should return route with origin as LatLng and destination as LatLng with c
   directionsService
     .route(request, (results, status) => {
       // Since origin and destination are both specified as parseable values, the only mocked
-      // LocationClient call should be the CalculateRouteCommand
-      expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-      expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteCommand));
+      // GeoPlacesClient call should be the CalculateRoutesCommand
+      expect(mockedRoutesClientSend).toHaveBeenCalledTimes(1);
+      expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
 
       const routes = results.routes;
-
       expect(routes.length).toStrictEqual(1);
 
       const route = routes[0];
-
-      const bounds = route.bounds;
-      expect(bounds.equals(new MigrationLatLngBounds(origin, destination))).toStrictEqual(true);
-
       const legs = route.legs;
 
       expect(legs.length).toStrictEqual(1);
 
       const leg = legs[0];
 
-      expect(leg.steps.length).toStrictEqual(3);
+      expect(leg.steps.length).toStrictEqual(7);
       expect(leg.start_location.equals(origin)).toStrictEqual(true);
       expect(leg.end_location.equals(destination)).toStrictEqual(true);
 
@@ -1225,68 +1443,6 @@ test("should return route with origin as LatLng and destination as LatLng with c
     .then(() => {
       done();
     });
-});
-
-test("should call route with options travel mode set to walking and unit system set to imperial", (done) => {
-  const request = {
-    origin: {
-      placeId: "KEEP_AUSTIN_WEIRD",
-    },
-    destination: {
-      query: "another cool place",
-    },
-    travelMode: TravelMode.WALKING,
-    unitSystem: UnitSystem.IMPERIAL,
-  };
-
-  directionsService.route(request).then(() => {
-    expect(mockedClientSendV1).toHaveBeenCalledWith(
-      expect.objectContaining({
-        input: {
-          CalculatorName: undefined,
-          DeparturePosition: [4, 3],
-          DestinationPosition: [8, 7],
-          IncludeLegGeometry: true,
-          TravelMode: "Walking",
-        },
-      }),
-    );
-
-    done();
-  });
-});
-
-test("should call route with options travel mode set to driving and unit system set to metric", (done) => {
-  const request = {
-    origin: {
-      placeId: "KEEP_AUSTIN_WEIRD",
-    },
-    destination: {
-      query: "another cool place",
-    },
-    travelMode: TravelMode.DRIVING,
-    unitSystem: UnitSystem.METRIC,
-    drivingOptions: {
-      departureTime: new Date("2000-01-01"),
-    },
-  };
-
-  directionsService.route(request).then(() => {
-    expect(mockedClientSendV1).toHaveBeenCalledWith(
-      expect.objectContaining({
-        input: {
-          CalculatorName: undefined,
-          DeparturePosition: [4, 3],
-          DepartureTime: new Date("2000-01-01"),
-          DestinationPosition: [8, 7],
-          IncludeLegGeometry: true,
-          TravelMode: "Car",
-        },
-      }),
-    );
-
-    done();
-  });
 });
 
 test("should call route with options avoidFerries set to true and avoidTolls set to true", (done) => {
@@ -1303,18 +1459,57 @@ test("should call route with options avoidFerries set to true and avoidTolls set
   };
 
   directionsService.route(request).then(() => {
-    expect(mockedClientSendV1).toHaveBeenCalledWith(
-      expect.objectContaining({
-        input: {
-          CalculatorName: undefined,
-          CarModeOptions: { AvoidFerries: true, AvoidTolls: true },
-          DeparturePosition: [4, 3],
-          DestinationPosition: [8, 7],
-          IncludeLegGeometry: true,
-          TravelMode: "Car",
-        },
-      }),
-    );
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+    expect(clientInput.Avoid?.Ferries).toStrictEqual(true);
+    expect(clientInput.Avoid?.TollRoads).toStrictEqual(true);
+    expect(clientInput.Avoid?.TollTransponders).toStrictEqual(true);
+
+    done();
+  });
+});
+
+test("should use correct travelMode when walking is specified", (done) => {
+  const request = {
+    origin: {
+      placeId: "KEEP_AUSTIN_WEIRD",
+    },
+    destination: {
+      query: "another cool place",
+    },
+    travelMode: TravelMode.WALKING,
+  };
+
+  directionsService.route(request).then(() => {
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+    expect(clientInput.TravelMode).toStrictEqual("Pedestrian");
+
+    done();
+  });
+});
+
+test("should use correct departureTime when when drivingOptions are specified", (done) => {
+  const request = {
+    origin: {
+      placeId: "KEEP_AUSTIN_WEIRD",
+    },
+    destination: {
+      query: "another cool place",
+    },
+    travelMode: TravelMode.DRIVING,
+    drivingOptions: {
+      departureTime: new Date("2020-04-22T17:57:24Z"),
+    },
+  };
+
+  directionsService.route(request).then(() => {
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+    expect(clientInput.DepartureTime).toStrictEqual("2020-04-22T17:57:24.000Z");
 
     done();
   });
@@ -1339,18 +1534,15 @@ test("should call route with option waypoints set", (done) => {
   };
 
   directionsService.route(request).then(() => {
-    expect(mockedClientSendV1).toHaveBeenCalledWith(
-      expect.objectContaining({
-        input: {
-          CalculatorName: undefined,
-          DeparturePosition: [4, 3],
-          DestinationPosition: [8, 7],
-          IncludeLegGeometry: true,
-          TravelMode: "Car",
-          WaypointPositions: [[8, 7]],
-        },
-      }),
-    );
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+    expect(clientInput.Waypoints).toStrictEqual([
+      {
+        Position: [8, 7],
+        PassThrough: false,
+      },
+    ]);
 
     done();
   });
@@ -1376,18 +1568,15 @@ test("should call route with option waypoints set and callback specified", (done
 
   directionsService
     .route(request, (_, status) => {
-      expect(mockedClientSendV1).toHaveBeenCalledWith(
-        expect.objectContaining({
-          input: {
-            CalculatorName: undefined,
-            DeparturePosition: [4, 3],
-            DestinationPosition: [8, 7],
-            IncludeLegGeometry: true,
-            TravelMode: "Car",
-            WaypointPositions: [[8, 7]],
-          },
-        }),
-      );
+      expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+      const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+      expect(clientInput.Waypoints).toStrictEqual([
+        {
+          Position: [8, 7],
+          PassThrough: false,
+        },
+      ]);
       expect(status).toStrictEqual(DirectionsStatus.OK);
     })
     .then(() => {
@@ -1557,9 +1746,9 @@ test("should return getDistanceMatrix with origin as Place.placeId and destinati
     // getDetails and findPlaceFromQuery request (respectively) to retrieve the location geometry,
     // so there will be a total of 3 mocked LocationClient.send calls (2 for places, 1 for distance matrix)
     expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-    expect(mockedClientSend).toHaveBeenCalledTimes(2);
-    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
-    expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+    expect(mockedPlacesClientSend).toHaveBeenCalledTimes(2);
+    expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
+    expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
     expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteMatrixCommand));
 
     const rows = response.rows;
@@ -1769,9 +1958,9 @@ test("getDistanceMatrix will invoke the callback if specified", (done) => {
   distanceMatrixService
     .getDistanceMatrix(request, (results, status) => {
       expect(mockedClientSendV1).toHaveBeenCalledTimes(1);
-      expect(mockedClientSend).toHaveBeenCalledTimes(2);
-      expect(mockedClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
-      expect(mockedClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
+      expect(mockedPlacesClientSend).toHaveBeenCalledTimes(2);
+      expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(SearchTextCommand));
+      expect(mockedPlacesClientSend).toHaveBeenCalledWith(expect.any(GetPlaceCommand));
       expect(mockedClientSendV1).toHaveBeenCalledWith(expect.any(CalculateRouteMatrixCommand));
 
       const rows = results.rows;


### PR DESCRIPTION
### Description
Migrated the `route` API to use the new standalone `GeoRoutes` client. This provides functional parity with our previous support of Google's inputs/response fields for `route` API. A follow-up PR will extend support to the additional features provided by the `GeoRoutes` client.
* Added support for `stopover` field on waypoints
* Added dependency on our `geo-routes` standalone client SDK and upgraded our client SDKs to the latest versions
   * This upgrade was made possible by upgrading to the new release of our auth-helper which had previously been dependent on an older version of `@smithy/core` that had conflicts with the newer client SDKs
* Removed mock response of `CalculateRouteCommand` in directions tests since it is no longer used
* Expanded supported documentation

### Testing
Ran unit tests and verified they all pass and still provide 100% coverage of directions module. Also ran directions example and verified it still works as expected, and now also supports the `stopover` field for waypoints.