### PR TITLE
Updated advanced example to display more place details

### DIFF
--- a/examples/advanced/advanced.css
+++ b/examples/advanced/advanced.css
@@ -26,25 +26,8 @@
   max-width: unset;
 }
 
-#search-details-container {
-  margin-left: 20px;
-  margin-right: 20px;
-}
-
-#search-details-name-container {
-  border-bottom: 2px solid lightgray;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
-}
-
 #details-name {
   font-size: 1.5em;
-}
-
-#search-details-buttons-container {
-  border-bottom: 2px solid lightgray;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
 }
 
 #search-results-container {
@@ -94,4 +77,102 @@
 #destination-container {
   margin: 20px;
   text-align: center;
+}
+
+.place-details-container {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin: 10px;
+  padding: 16px;
+  font-family: Arial, sans-serif;
+  max-width: 400px;
+}
+
+.place-name {
+  font-size: 20px;
+  font-weight: bold;
+  color: #202124;
+  margin-bottom: 12px;
+}
+
+.detail-section {
+  padding: 8px 0;
+  border-bottom: 1px solid #e8eaed;
+  display: flex;
+}
+
+.detail-section:last-child {
+  border-bottom: none;
+}
+
+.detail-section a {
+  color: #1a73e8;
+  text-decoration: none;
+}
+
+.detail-section a:hover {
+  text-decoration: underline;
+}
+
+.detail-icon {
+  width: 20px;
+  display: inline-block;
+  color: #5f6368;
+  margin-right: 12px;
+  vertical-align: top;
+}
+
+.detail-content {
+  display: inline-block;
+  width: calc(100% - 32px);
+}
+
+#hours-section {
+  display: block;
+}
+
+.hours-collapsed {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.hours-toggle {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: #5f6368;
+}
+
+.hours-expanded {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #e8eaed;
+  display: none;
+}
+
+.hours-day {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  color: #3c4043;
+}
+
+.hours-day.current {
+  font-weight: bold;
+  color: #1a73e8;
+}
+
+.status-open {
+  color: #188038;
+  font-weight: bold;
+}
+
+.status-closed {
+  color: #d93025;
+  font-weight: bold;
 }

--- a/examples/advanced/google.template.html
+++ b/examples/advanced/google.template.html
@@ -1,6 +1,10 @@
 <html>
   <head>
     <title>Advanced Example - Google</title>
+
+    <!-- Need this so that the place details symbols show up properly -->
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
     <link rel="stylesheet" type="text/css" href="./advanced.css" />
 
@@ -26,17 +30,44 @@
           <button id="back-to-results-button">Back to results</button>
         </div>
 
-        <div id="search-details-container">
-          <div id="search-details-name-container">
-            <span id="details-name">Name Goes Here</span>
-          </div>
-          <div id="search-details-buttons-container">
+        <div class="place-details-container" id="place-details-panel" style="display: none">
+          <div class="place-name" id="place-name"></div>
+
+          <div class="detail-section" id="buttons-section">
             <button id="details-get-directions">Directions</button>
           </div>
-          <div id="search-details-fields-container">
-            <span id="details-formatted-address">Address Goes Here</span>
+
+          <div class="detail-section" id="address-section">
+            <span class="detail-icon">📍</span>
+            <span class="detail-content" id="place-address"></span>
+          </div>
+
+          <div class="detail-section" id="hours-section">
+            <div class="hours-collapsed">
+              <span class="detail-icon">🕒</span>
+              <div class="detail-content">
+                <span id="hours-status"></span>
+              </div>
+              <button class="hours-toggle" id="hours-toggle">▼</button>
+            </div>
+            <div class="hours-expanded" id="hours-expanded"></div>
+          </div>
+
+          <div class="detail-section" id="website-section">
+            <span class="detail-icon">🌐</span>
+            <span class="detail-content">
+              <a id="place-website" target="_blank"></a>
+            </span>
+          </div>
+
+          <div class="detail-section" id="phone-section">
+            <span class="detail-icon">📞</span>
+            <span class="detail-content">
+              <a id="place-phone"></a>
+            </span>
           </div>
         </div>
+
         <div id="search-results-container">
           <ul id="search-results-list"></ul>
         </div>

--- a/examples/advanced/index.template.html
+++ b/examples/advanced/index.template.html
@@ -1,6 +1,10 @@
 <html>
   <head>
     <title>Advanced Example - Migration SDK</title>
+
+    <!-- Need this so that the place details symbols show up properly -->
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
     <link rel="stylesheet" type="text/css" href="../common/style.css" />
     <link rel="stylesheet" type="text/css" href="./advanced.css" />
 
@@ -26,17 +30,44 @@
           <button id="back-to-results-button">Back to results</button>
         </div>
 
-        <div id="search-details-container">
-          <div id="search-details-name-container">
-            <span id="details-name">Name Goes Here</span>
-          </div>
-          <div id="search-details-buttons-container">
+        <div class="place-details-container" id="place-details-panel" style="display: none">
+          <div class="place-name" id="place-name"></div>
+
+          <div class="detail-section" id="buttons-section">
             <button id="details-get-directions">Directions</button>
           </div>
-          <div id="search-details-fields-container">
-            <span id="details-formatted-address">Address Goes Here</span>
+
+          <div class="detail-section" id="address-section">
+            <span class="detail-icon">📍</span>
+            <span class="detail-content" id="place-address"></span>
+          </div>
+
+          <div class="detail-section" id="hours-section">
+            <div class="hours-collapsed">
+              <span class="detail-icon">🕒</span>
+              <div class="detail-content">
+                <span id="hours-status"></span>
+              </div>
+              <button class="hours-toggle" id="hours-toggle">▼</button>
+            </div>
+            <div class="hours-expanded" id="hours-expanded"></div>
+          </div>
+
+          <div class="detail-section" id="website-section">
+            <span class="detail-icon">🌐</span>
+            <span class="detail-content">
+              <a id="place-website" target="_blank"></a>
+            </span>
+          </div>
+
+          <div class="detail-section" id="phone-section">
+            <span class="detail-icon">📞</span>
+            <span class="detail-content">
+              <a id="place-phone"></a>
+            </span>
           </div>
         </div>
+
         <div id="search-results-container">
           <ul id="search-results-list"></ul>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-geo-places": "^3.808.0",
         "@aws-sdk/client-geo-routes": "3.808.0",
         "@aws-sdk/client-location": "^3.808.0",
-        "@aws/amazon-location-for-maplibre-gl-geocoder": "^2.0.2",
+        "@aws/amazon-location-for-maplibre-gl-geocoder": "^2.0.3",
         "@aws/amazon-location-utilities-auth-helper": "^1.2.2",
         "@turf/turf": "^7.1.0",
         "libphonenumber-js": "^1.11.16",
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/@aws/amazon-location-for-maplibre-gl-geocoder": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws/amazon-location-for-maplibre-gl-geocoder/-/amazon-location-for-maplibre-gl-geocoder-2.0.2.tgz",
-      "integrity": "sha512-hCST3Ab8E7kjfMgExk298fFtFguV09w+Aglx33M2izfJ/F4F6FleL3GA1bu8YUc2B8nqw2dqriWYOD1iVKnskg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws/amazon-location-for-maplibre-gl-geocoder/-/amazon-location-for-maplibre-gl-geocoder-2.0.3.tgz",
+      "integrity": "sha512-O/NoeIZqPq01ZUkwIV+wm68Kk4Uk/sdULtlcQfw7bD3Dj5H0BCvHCvwgFWiN1RwelY6twfEtzIqxfY8jq3MFpw==",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.683.0",
         "@aws-sdk/client-location": "^3.682.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@aws-sdk/client-geo-places": "^3.808.0",
     "@aws-sdk/client-geo-routes": "3.808.0",
     "@aws-sdk/client-location": "^3.808.0",
-    "@aws/amazon-location-for-maplibre-gl-geocoder": "^2.0.2",
+    "@aws/amazon-location-for-maplibre-gl-geocoder": "^2.0.3",
     "@aws/amazon-location-utilities-auth-helper": "^1.2.2",
     "@turf/turf": "^7.1.0",
     "libphonenumber-js": "^1.11.16",


### PR DESCRIPTION
### Description
Improved the advanced example by showcasing new place properties in the display panel.
* Added collapsible opening hours display in the place panel
* Also added website and phone number
* Upgraded to latest `@aws/amazon-location-for-maplibre-gl-geocoder` in order to get additional properties in the responses (e.g. opening hours)
* Some minor stylistic improvements

![UpdatedAdvancedExample](https://github.com/user-attachments/assets/d72b4915-cf50-4bab-ac15-50442001214e)

### Testing
Tested the advanced example for several place types (e.g. restaurants, stores, houses) and verified that when applicable the additional place details were displayed.