### PR TITLE
Added support for the NPM loader pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /examples/config.json
 index.html
 google.html
+# special-case to ignore generated js files for npm loader example
+/examples/npmLoader/exampleGoogle.js
+/examples/npmLoader/example.js
 
 # generated version file
 /src/version.ts

--- a/README.md
+++ b/README.md
@@ -6,18 +6,11 @@ The Amazon Location Migration SDK provides a bridge that allows you to migrate e
 
 ## Usage
 
-In order to use the SDK, you will first need to create Amazon Location Service resources based on what kinds of Google Maps API calls your application uses.
-Please follow the instructions linked below based on your applications needs:
-
-- Maps - https://docs.aws.amazon.com/location/latest/developerguide/map-prerequisites.html
-- Places - https://docs.aws.amazon.com/location/latest/developerguide/places-prerequisites.html
-- Routes - https://docs.aws.amazon.com/location/latest/developerguide/routes-prerequisites.html
-
-Once you have created your resources, you can create an API key and give it access to the resources you've created:
+In order to use the SDK, all you need to do is create an API key, which can be done by following these instructions:
 
 https://docs.aws.amazon.com/location/latest/developerguide/using-apikeys.html
 
-Now that you have your resources and API key, you can replace your Google Maps JavaScript API import with the SDK. Here are examples based on which Google import method your application uses:
+Once you have your API key, you can replace your Google Maps JavaScript API import with the SDK. Here are examples based on which Google import method your application uses:
 
 ### Dynamic Library Import
 
@@ -34,13 +27,11 @@ If your application uses the [dynamic library import](https://developers.google.
 </script>
 ```
 
-To use the migration SDK, you replace that line with the following (with your AWS region, resource name(s) and API key filled in):
+To use the migration SDK, you replace that line with the following (with your AWS region and API key filled in):
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@aws/amazon-location-migration-sdk/dist/amazonLocationMigrationSDK.min.js?region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"></script>
 ```
-
-If there are any resources that your application doesn't use, you can omit those query parameters. Only the `region` and `apiKey` are required.
 
 The import is the only change you need to make in your client code. The rest of your code will function as-is but will now be making Amazon Location Service API requests, such as the example below:
 
@@ -70,7 +61,7 @@ If your application uses the [legacy direct script loading tag](https://develope
 ></script>
 ```
 
-To use the migration SDK, you replace that line with the following (with your AWS region, resource name(s) and API key filled in):
+To use the migration SDK, you replace that line with the following (with your AWS region and API key filled in):
 
 ```html
 <script
@@ -78,8 +69,6 @@ To use the migration SDK, you replace that line with the following (with your AW
   src="https://cdn.jsdelivr.net/npm/@aws/amazon-location-migration-sdk/dist/amazonLocationMigrationSDK.min.js?callback=initMap&region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
 ></script>
 ```
-
-If there are any resources that your application doesn't use, you can omit those query parameters. Only the `region` and `apiKey` are required.
 
 The import is the only change you need to make in your client code. The rest of your code will function as-is but will now be making Amazon Location Service API requests, such as the example below:
 
@@ -94,6 +83,66 @@ function initMap() {
 }
 
 window.initMap = initMap;
+```
+
+### NPM js-api-loader usage
+
+If your application uses the [NPM js-api-loader](https://developers.google.com/maps/documentation/javascript/load-maps-js-api#js-api-loader) package, your current import looks something like this:
+
+```javascript
+import { Loader } from "@googlemaps/js-api-loader";
+
+const loader = new Loader({
+  apiKey: "YOUR_API_KEY",
+  version: "weekly",
+  ...additionalOptions,
+});
+
+loader.load().then(async () => {
+  const { Map } = await google.maps.importLibrary("maps");
+
+  map = new Map(document.getElementById("map"), {
+    center: { lat: 30.268193, lng: -97.7457518 },
+    zoom: 8,
+  });
+});
+```
+
+To use the migration SDK, you just need to replace the `apiKey` field with your Amazon Location API key and also add a field replace to specify your `region` (unless you are using `us-west-2`, which it will use by default if no `region` is passed).
+The logic when you call `load` and beyond remains the same:
+
+```javascript
+import { Loader } from "@googlemaps/js-api-loader";
+
+const loader = new Loader({
+  apiKey: "AMAZON_LOCATION_API_KEY",
+  region: "AMAZON_LOCATION_REGION",
+  version: "weekly",
+  ...additionalOptions,
+});
+
+loader.load().then(async () => {
+  const { Map } = await google.maps.importLibrary("maps");
+
+  map = new Map(document.getElementById("map"), {
+    center: { lat: 30.268193, lng: -97.7457518 },
+    zoom: 8,
+  });
+});
+```
+
+The migration SDK also supports using `loader.importLibrary()` to load libraries:
+
+```javascript
+const loader = new Loader({
+  apiKey: "YOUR_API_KEY",
+  version: "weekly",
+  ...additionalOptions,
+});
+
+loader.importLibrary("maps").then(({ Map }) => {
+  new Map(document.getElementById("map"), mapOptions);
+});
 ```
 
 ## Supported Google APIs

--- a/examples/generate.js
+++ b/examples/generate.js
@@ -8,18 +8,18 @@ const Mustache = require("mustache");
 // Retrieve the user's config for the placeholder values
 const exampleConfig = require("./config.json");
 
-// Find all of the templated html files in our examples
-const templateFiles = globSync("./examples/**/*.template.html");
+// Find all of the templated files in our examples
+const templateFiles = globSync("./examples/*/**/*.template.*");
 
-// Generate .html files from all of our templates, after replacing the placeholder values
+// Generate files from all of our templates, after replacing the placeholder values
 for (const file of templateFiles) {
   const template = fs.readFileSync(file).toString();
 
-  // Generate our new html using mustache to replace the templated values
-  const generatedHtml = Mustache.render(template, exampleConfig);
+  // Generate our new file using mustache to replace the templated values
+  const generatedFile = Mustache.render(template, exampleConfig);
 
-  console.log(`Generating html from template: ${file}`);
+  console.log(`Generating file from template: ${file}`);
 
   const generatedFileName = file.replace(".template", "");
-  fs.writeFileSync(generatedFileName, generatedHtml);
+  fs.writeFileSync(generatedFileName, generatedFile);
 }

--- a/examples/landingPage.html
+++ b/examples/landingPage.html
@@ -39,6 +39,11 @@
     </div>
 
     <div>
+      <span class="example-links"><a href="./npmLoader/index.html" target="_blank">NPM Loader</a></span>
+      <span><a href="./npmLoader/google.html" target="_blank">(Google)</a></span>
+    </div>
+
+    <div>
       <span class="example-links"><a href="./directions/index.html" target="_blank">Directions</a></span>
       <span><a href="./directions/google.html" target="_blank">(Google)</a></span>
     </div>

--- a/examples/npmLoader/example.template.js
+++ b/examples/npmLoader/example.template.js
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This example showcases importing the SDK through the NPM Loader.
+// The underlying logic is the same as the Autocomplete example.
+//
+// This is meant to be showcased as the client logic that is able to remain largely untouched
+// and retain the same functionality when using the Amazon Location Migration SDK.
+
+// In production, this would be imported from "@aws/amazon-location-migration-sdk"
+import { Loader } from "../../dist/esm/index";
+
+// This initMap has all of the actual implementation of the example so that we can
+// isolate show-casing the NPM Loader usage below
+import { initMap } from "./logic";
+
+const loader = new Loader({
+  apiKey: "{{AMAZON_LOCATION_API_KEY}}",
+  region: "{{REGION}}", // The only difference in the API call is needing to add your region
+  version: "weekly",
+});
+
+// Load the SDK and then invoke our underlying logic that sets up the example
+loader.load().then(initMap);

--- a/examples/npmLoader/exampleGoogle.template.js
+++ b/examples/npmLoader/exampleGoogle.template.js
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This example showcases importing the SDK through the NPM Loader.
+// The underlying logic is the same as the Autocomplete example.
+//
+// This is meant to be showcased as the client logic that is able to remain largely untouched
+// and retain the same functionality when using the Amazon Location Migration SDK.
+
+import { Loader } from "@googlemaps/js-api-loader";
+
+// This initMap has all of the actual implementation of the example so that we can
+// isolate show-casing the NPM Loader usage below
+import { initMap } from "./logic";
+
+const loader = new Loader({
+  apiKey: "{{GOOGLE_API_KEY}}",
+  version: "weekly",
+});
+
+// Load the SDK and then invoke our underlying logic that sets up the example
+loader.load().then(initMap);

--- a/examples/npmLoader/google.template.html
+++ b/examples/npmLoader/google.template.html
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <title>NPM Loader Example - Google</title>
+    <link rel="stylesheet" type="text/css" href="../common/style.css" />
+
+    <!-- jQuery imports for example -->
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+
+    <!-- Client logic example -->
+    <script type="module" src="./exampleGoogle.js"></script>
+  </head>
+  <body>
+    <!-- Search box and map elements for the example -->
+    <div id="search-container">
+      <input id="search-input" type="text" placeholder="Search Box" />
+    </div>
+    <div id="map"></div>
+  </body>
+</html>

--- a/examples/npmLoader/index.template.html
+++ b/examples/npmLoader/index.template.html
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <title>NPM Loader Example - Migration SDK</title>
+    <link rel="stylesheet" type="text/css" href="../common/style.css" />
+
+    <!-- jQuery imports for example -->
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css" />
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+
+    <!-- Client logic example -->
+    <script type="module" src="./example.js"></script>
+  </head>
+  <body>
+    <!-- Search box and map elements for the example -->
+    <div id="search-container">
+      <input id="search-input" type="text" placeholder="Search Box" />
+    </div>
+    <div id="map"></div>
+  </body>
+</html>

--- a/examples/npmLoader/logic.js
+++ b/examples/npmLoader/logic.js
@@ -1,0 +1,185 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the same logic from the Autocomplete example. The only difference is that we use the NPM Loader
+// pattern in example/Google.js to call initMap instead of the callback from importing the SDKs in browser
+//
+// This example has a Google Map, with an input box for autocomplete queries.
+// The results from the autocomplete queries are used to then trigger a getDetails, from which
+// a marker is placed at that location and the map moves to the selected place.
+//
+// This is meant to be showcased as the client logic that is able to remain untouched
+// and retain the same functionality when using the Amazon Location Migration SDK.
+
+let map;
+let placesService;
+let predictionItems = [];
+let markers = [];
+
+export async function initMap() {
+  const austinCoords = { lat: 30.268193, lng: -97.7457518 }; // Austin, TX :)
+
+  const { Map } = await google.maps.importLibrary("maps");
+  map = new Map(document.getElementById("map"), {
+    center: austinCoords,
+    zoom: 11,
+    mapId: "DEMO_MAP_ID",
+  });
+
+  const { AutocompleteService, PlacesService, PlacesServiceStatus } = await google.maps.importLibrary("places");
+  placesService = new PlacesService(map);
+  const autocompleteService = new AutocompleteService();
+
+  const searchInput = $("#search-input");
+  searchInput.autocomplete({
+    delay: 50,
+    select: function (event, ui) {
+      for (let i = 0; i < predictionItems.length; i++) {
+        let prediction = predictionItems[i];
+        if (prediction.description === ui.item.label) {
+          getPredictionInfo(prediction);
+
+          // Clear our cached prediction items after making selection,
+          // otherwise when the input widget loses focus it will trigger
+          // the change again
+          predictionItems = [];
+          break;
+        }
+      }
+    },
+    source: function (request, response) {
+      autocompleteService.getQueryPredictions(
+        {
+          input: request.term,
+          locationBias: map.getCenter(),
+        },
+        function (predictions, status) {
+          if (status != PlacesServiceStatus.OK || !predictions) {
+            response([]);
+            return;
+          }
+
+          // Cache our current prediction items so we can later do a getDetails request
+          // using the placeId
+          predictionItems = predictions;
+
+          const results = predictions.map((prediction) => prediction.description);
+
+          response(results);
+        },
+      );
+    },
+  });
+
+  const input = document.getElementById("search-input");
+  input.addEventListener("change", function (event) {
+    // If we got this change event, the user pressed Enter without selecting
+    // an item from the suggestions drop-down, so just choose the first
+    // prediction in the list.
+    if (predictionItems.length) {
+      const prediction = predictionItems[0];
+
+      // Update the search input field with the full place description from the prediction list
+      // and close the prediction list
+      searchInput.val(prediction.description);
+      searchInput.autocomplete("close");
+
+      getPredictionInfo(prediction);
+    }
+  });
+}
+
+function getPredictionInfo(prediction) {
+  // Clear out any previous markers before we place new ones for the new prediction
+  markers.map((marker) => {
+    marker.setMap(null);
+  });
+  markers = [];
+
+  // If the prediction has a place_id, then we can do a getDetails
+  // Otherwise, the prediction is a query string (e.g. whataburgers in austin)
+  // so instead we need to do a textSearch to gather the place results
+  if (prediction.place_id) {
+    getPlaceDetails(prediction.place_id);
+  } else {
+    getTextSearch(prediction.description);
+  }
+}
+
+async function getPlaceDetails(placeId) {
+  const { PlacesServiceStatus } = await google.maps.importLibrary("places");
+
+  var request = {
+    placeId: placeId,
+  };
+
+  placesService.getDetails(request, function (result, status) {
+    if (status === PlacesServiceStatus.OK) {
+      createMarker(result);
+      map.setCenter(result.geometry.location);
+      map.setZoom(14);
+    }
+  });
+}
+
+async function getTextSearch(query) {
+  var request = {
+    query: query,
+    location: map.getCenter(),
+  };
+
+  const { PlacesServiceStatus } = await google.maps.importLibrary("places");
+
+  const { LatLngBounds } = await google.maps.importLibrary("core");
+  const resultsBounds = new LatLngBounds();
+
+  placesService.textSearch(request, function (results, status) {
+    if (status === PlacesServiceStatus.OK) {
+      results.map((result) => {
+        createMarker(result);
+
+        resultsBounds.extend(result.geometry.location);
+      });
+
+      // Adjust the map to fit all the new markers we added
+      const paddingInPixels = 50;
+      map.fitBounds(resultsBounds, paddingInPixels);
+    }
+  });
+}
+
+async function createMarker(place) {
+  if (!place.geometry || !place.geometry.location) return;
+
+  const { AdvancedMarkerElement } = await google.maps.importLibrary("marker");
+  const marker = new AdvancedMarkerElement({
+    map,
+    position: place.geometry.location,
+  });
+
+  createInfoWindow(marker, place);
+
+  markers.push(marker);
+}
+
+async function createInfoWindow(marker, place) {
+  const infoWindowContainer = document.createElement("div");
+  const infoWindowHeader = document.createElement("h2");
+  const infoWindowBody = document.createElement("p");
+  infoWindowHeader.textContent = place.name;
+  infoWindowBody.textContent = place.formatted_address;
+  infoWindowContainer.appendChild(infoWindowHeader);
+  infoWindowContainer.appendChild(infoWindowBody);
+
+  const infoWindow = new google.maps.InfoWindow({
+    content: infoWindowContainer,
+    minWidth: 300,
+  });
+
+  marker.addListener("click", () => {
+    infoWindow.open({
+      map,
+      anchor: marker,
+    });
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@babel/core": "^7.21.8",
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-typescript": "^7.21.5",
+        "@googlemaps/js-api-loader": "^1.16.8",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-commonjs": "^25.0.2",
         "@rollup/plugin-json": "^6.0.0",
@@ -3317,6 +3318,13 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@babel/core": "^7.21.8",
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-typescript": "^7.21.5",
+    "@googlemaps/js-api-loader": "^1.16.8",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^25.0.2",
     "@rollup/plugin-json": "^6.0.0",

--- a/test/npm_loader.test.ts
+++ b/test/npm_loader.test.ts
@@ -1,0 +1,195 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Import the migration SDK index. Unlike the index.test.ts, we don't setup a mock currentScript, so this
+// test file can test being imported through the NPM Loader pattern
+import { Loader } from "../src/index";
+
+// Spy on console.error so we can verify it gets called in error cases
+jest.spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("importing the SDK through the NPM Loader should populate google.maps namespace", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  // Dynamically load the migration SDK
+  await loader.load();
+
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const google = (window as any).google;
+
+  // Core classes
+  expect(google.maps).toHaveProperty("Circle");
+  expect(google.maps).toHaveProperty("ColorScheme");
+  expect(google.maps).toHaveProperty("ControlPosition");
+  expect(google.maps).toHaveProperty("LatLng");
+  expect(google.maps).toHaveProperty("LatLngBounds");
+  expect(google.maps).toHaveProperty("MVCObject");
+  expect(google.maps).toHaveProperty("event");
+
+  // Maps and controls (e.g. Markers)
+  expect(google.maps).toHaveProperty("Map");
+  expect(google.maps).toHaveProperty("MapTypeId");
+  expect(google.maps).toHaveProperty("Marker");
+  expect(google.maps.marker).toHaveProperty("AdvancedMarkerElement");
+
+  // Directions classes
+  expect(google.maps).toHaveProperty("DirectionsRenderer");
+  expect(google.maps).toHaveProperty("DirectionsService");
+  expect(google.maps).toHaveProperty("DirectionsStatus");
+  expect(google.maps).toHaveProperty("TravelMode");
+  expect(google.maps).toHaveProperty("DistanceMatrixService");
+  expect(google.maps).toHaveProperty("DistanceMatrixElementStatus");
+  expect(google.maps).toHaveProperty("DistanceMatrixStatus");
+
+  // Places classes
+  expect(google.maps.places).toHaveProperty("AddressComponent");
+  expect(google.maps.places).toHaveProperty("Autocomplete");
+  expect(google.maps.places).toHaveProperty("AutocompleteService");
+  expect(google.maps.places).toHaveProperty("OpeningHours");
+  expect(google.maps.places).toHaveProperty("OpeningHoursPeriod");
+  expect(google.maps.places).toHaveProperty("OpeningHoursPoint");
+  expect(google.maps.places).toHaveProperty("Place");
+  expect(google.maps.places).toHaveProperty("PlacesService");
+  expect(google.maps.places).toHaveProperty("PlacesServiceStatus");
+  expect(google.maps.places).toHaveProperty("PlusCode");
+  expect(google.maps.places).toHaveProperty("SearchBox");
+
+  // Geocoder classes
+  expect(google.maps).toHaveProperty("Geocoder");
+  expect(google.maps).toHaveProperty("GeocoderStatus");
+});
+
+test("can dynamically import core classes through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const { ColorScheme, ControlPosition, LatLng, LatLngBounds, MVCObject, event } = (await loader.importLibrary(
+    "core",
+  )) as google.maps.CoreLibrary;
+
+  expect(ColorScheme).toBeDefined();
+  expect(ControlPosition).toBeDefined();
+  expect(LatLng).toBeDefined();
+  expect(LatLngBounds).toBeDefined();
+  expect(MVCObject).toBeDefined();
+  expect(event.addListener).toBeDefined();
+  expect(event.addListenerOnce).toBeDefined();
+  expect(event.removeListener).toBeDefined();
+});
+
+test("can dynamically import maps classes through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const { Circle, InfoWindow, Map, MapTypeId } = (await loader.importLibrary("maps")) as google.maps.MapsLibrary;
+
+  expect(Circle).toBeDefined();
+  expect(InfoWindow).toBeDefined();
+  expect(Map).toBeDefined();
+  expect(MapTypeId).toBeDefined();
+});
+
+test("can dynamically import places classes through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const {
+    AddressComponent,
+    Autocomplete,
+    AutocompleteService,
+    OpeningHours,
+    OpeningHoursPeriod,
+    OpeningHoursPoint,
+    Place,
+    PlacesService,
+    PlacesServiceStatus,
+    PlusCode,
+    SearchBox,
+  } = (await loader.importLibrary("places")) as google.maps.PlacesLibrary;
+
+  expect(AddressComponent).toBeDefined();
+  expect(Autocomplete).toBeDefined();
+  expect(AutocompleteService).toBeDefined();
+  expect(OpeningHours).toBeDefined();
+  expect(OpeningHoursPeriod).toBeDefined();
+  expect(OpeningHoursPoint).toBeDefined();
+  expect(Place).toBeDefined();
+  expect(PlacesService).toBeDefined();
+  expect(PlacesServiceStatus).toBeDefined();
+  expect(PlusCode).toBeDefined();
+  expect(SearchBox).toBeDefined();
+});
+
+test("can dynamically import routes classes through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const {
+    DirectionsRenderer,
+    DirectionsService,
+    DistanceMatrixService,
+    DirectionsStatus,
+    TravelMode,
+    DistanceMatrixElementStatus,
+    DistanceMatrixStatus,
+  } = (await loader.importLibrary("routes")) as google.maps.RoutesLibrary;
+
+  expect(DirectionsRenderer).toBeDefined();
+  expect(DirectionsService).toBeDefined();
+  expect(DistanceMatrixService);
+  expect(DirectionsStatus).toBeDefined();
+  expect(TravelMode).toBeDefined();
+  expect(DistanceMatrixElementStatus).toBeDefined();
+  expect(DistanceMatrixStatus).toBeDefined();
+});
+
+test("can dynamically import marker classes through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const { AdvancedMarkerElement, Marker } = (await loader.importLibrary("marker")) as google.maps.MarkerLibrary;
+
+  expect(AdvancedMarkerElement).toBeDefined();
+  expect(Marker).toBeDefined();
+});
+
+test("can dynamically import geocoder classes through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const { Geocoder, GeocoderStatus } = (await loader.importLibrary("geocoding")) as google.maps.GeocodingLibrary;
+
+  expect(Geocoder).toBeDefined();
+  expect(GeocoderStatus).toBeDefined();
+});
+
+test("should report an error if a library we don't support is requested through the NPM Loader", async () => {
+  const loader = new Loader({
+    apiKey: "testAPIKey",
+    region: "us-west-2",
+  });
+
+  const { HeatmapLayer } = (await loader.importLibrary("visualization")) as google.maps.VisualizationLibrary;
+
+  expect(HeatmapLayer).toBeUndefined();
+  expect(console.error).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
### Description
Added support for the [@googlemaps/js-api-loader](https://www.npmjs.com/package/@googlemaps/js-api-loader) import pattern. Even though Google's documentation lists is as the third (deprecated) option for importing their SDK, the package has ~1.7M weekly downloads, so it seems like there is a good chance prospective users are using it.

The generate logic for the local example has updated in order to process any kind of templated files instead of just `.html` (this was done because we now needed to templatize the `.js` files for the NPM loader example, since they pass in the `apiKey` in the script itself).

I also updated the `README` with directions on how to migrate this newly supported pattern. While I was in the `README`, I cleaned up some lingering references to creating maps/places/routes resources.

### Testing
Added an NPM loader example, that has the exact same logic as our existing Autocomplete example, it just uses the NPM loader import instead. Added `@googlemaps/js-api-loader` as a dev dependency so it could be used in the Google version of the example. Added new unit tests to test both the `load` and `importLibrary` patterns. Also built/ran all local examples and verified both the existing examples and the new NPM loader all work as expected.