### PR TITLE
Add copyrights and route summary in DirectionsRoute

### DIFF
--- a/src/directions/directions_service.ts
+++ b/src/directions/directions_service.ts
@@ -28,7 +28,7 @@ import {
 const KILOMETERS_TO_METERS_CONSTANT = 1000;
 // place_id and types needed for geocoded_waypoints response property, formatted_address needed for leg start_address and end_address
 const ROUTE_FIND_LOCATION_FIELDS = ["geometry", "place_id", "types", "formatted_address"];
-
+const AWS_COPYRIGHT = "© AWS, HERE";
 export class MigrationDirectionsService {
   // This will be populated by the top level module
   // that creates our GeoRoutes client
@@ -271,11 +271,11 @@ export class MigrationDirectionsService {
       const googleRoute: google.maps.DirectionsRoute = {
         bounds: bounds,
         legs: googleLegs,
+        copyrights: AWS_COPYRIGHT,
+        summary: route.MajorRoadLabels?.[0]?.RoadName?.Value || "",
         // TODO: These are not currently supported, but are required in the response
-        copyrights: "",
         overview_path: [],
         overview_polyline: "",
-        summary: "",
         warnings: [],
         waypoint_order: [],
       };

--- a/src/directions/directions_service.ts
+++ b/src/directions/directions_service.ts
@@ -324,19 +324,27 @@ export class MigrationDirectionsService {
    * @returns Formatted summary string of the route
    */
   private _getSummary(route: Route): string {
-    if (!route.MajorRoadLabels) return "";
+    if (!route.MajorRoadLabels) {
+      return "";
+    }
 
     // Get valid road names, filtering out undefined/null values
     const validRoads = route.MajorRoadLabels.map((label) => label?.RoadName?.Value).filter((roadName) => roadName);
 
-    if (!validRoads.length) return "";
+    if (!validRoads.length) {
+      return "";
+    }
 
-    if (validRoads.length === 1) return validRoads[0];
+    if (validRoads.length === 1) {
+      return validRoads[0];
+    }
 
     const firstValidRoad = validRoads[0];
     const lastValidRoad = validRoads[validRoads.length - 1];
 
-    if (firstValidRoad === lastValidRoad) return firstValidRoad;
+    if (firstValidRoad === lastValidRoad) {
+      return firstValidRoad;
+    }
 
     // Return combination of first and last valid roads
     return `${firstValidRoad} and ${lastValidRoad}`;

--- a/test/directions.test.ts
+++ b/test/directions.test.ts
@@ -3851,3 +3851,268 @@ test("should call getDistanceMatrix with options avoidHighways set to true", (do
     done();
   });
 });
+
+test("should have copyrights field in route response", (done) => {
+  const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+  const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
+
+  const request = {
+    origin: origin,
+    destination: destination,
+    travelMode: TravelMode.DRIVING,
+  };
+
+  directionsService.route(request).then((response) => {
+    const routes = response.routes;
+    expect(routes.length).toStrictEqual(1);
+
+    const route = routes[0];
+    expect(route.copyrights).toBeDefined();
+    expect(route.copyrights).toStrictEqual("© AWS, HERE");
+
+    done();
+  });
+});
+
+describe("test summary field in route response", () => {
+  test("should have summary field with road name when available", (done) => {
+    const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+    const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
+
+    const request = {
+      origin: origin,
+      destination: destination,
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      const routes = response.routes;
+      expect(routes.length).toStrictEqual(1);
+
+      const route = routes[0];
+
+      expect(route.summary).toBeDefined();
+      expect(route.summary).toStrictEqual("Guadalupe St");
+
+      done();
+    });
+  });
+
+  test("should have empty summary field when no road name is available", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: [],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const origin = new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]);
+    const destination = new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]);
+
+    const request = {
+      origin: origin,
+      destination: destination,
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      const routes = response.routes;
+      expect(routes.length).toStrictEqual(1);
+
+      const route = routes[0];
+      // Verify that summary field exists but is empty when no road name is available
+      expect(route.summary).toBeDefined();
+      expect(route.summary).toStrictEqual("");
+
+      done();
+    });
+  });
+
+  test("should have summary field with road name when all properties are available", (done) => {
+    // Mock response with complete road name data
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: [
+              {
+                RoadName: {
+                  Value: "Main Street",
+                },
+              },
+            ],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("Main Street");
+      done();
+    });
+  });
+
+  test("should have empty summary when MajorRoadLabels is undefined", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            // MajorRoadLabels: [],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("");
+      done();
+    });
+  });
+
+  test("should have empty summary when MajorRoadLabels array is empty", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: [],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("");
+      done();
+    });
+  });
+
+  test("should have empty summary when RoadName is undefined", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: [{}],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("");
+      done();
+    });
+  });
+
+  test("should have empty summary when RoadName.Value is undefined", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: [
+              {
+                RoadName: {},
+              },
+            ],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("");
+      done();
+    });
+  });
+
+  test("should have empty summary when RoadName.Value is null", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: [
+              {
+                RoadName: {
+                  Value: null,
+                },
+              },
+            ],
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("");
+      done();
+    });
+  });
+
+  test("should have empty summary when MajorRoadLabels is null", (done) => {
+    mockedRoutesClientSend.mockImplementationOnce(() =>
+      Promise.resolve({
+        Routes: [
+          {
+            MajorRoadLabels: null,
+            Legs: [],
+          },
+        ],
+      }),
+    );
+
+    const request = {
+      origin: new MigrationLatLng(testDeparturePosition[1], testDeparturePosition[0]),
+      destination: new MigrationLatLng(testArrivalPosition[1], testArrivalPosition[0]),
+      travelMode: TravelMode.DRIVING,
+    };
+
+    directionsService.route(request).then((response) => {
+      expect(response.routes[0].summary).toStrictEqual("");
+      done();
+    });
+  });
+});


### PR DESCRIPTION
1) Add copyrights "© AWS, HERE" to DirectionsRoute
2) Add route summary in DirectionsRoute which is the identifying major road on the route leg. 

-----------------------------|---------|----------|---------|---------|-------------------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s             
-----------------------------|---------|----------|---------|---------|-------------------------------
All files                    |   99.09 |    94.69 |   99.12 |   99.08 |                               
 src                         |     100 |    96.92 |     100 |     100 |                               
  events.ts                  |     100 |    94.59 |     100 |     100 | 20                            
  geocoder.ts                |     100 |      100 |     100 |     100 |                               
  index.ts                   |     100 |      100 |     100 |     100 |                               
  version.ts                 |     100 |      100 |     100 |     100 |                               
 src/common                  |   97.85 |    89.76 |   96.49 |   97.83 |                               
  circle.ts                  |   93.45 |    81.15 |   94.11 |   93.45 | 214-218,231-236               
  defines.ts                 |     100 |      100 |     100 |     100 |                               
  helpers.ts                 |     100 |      100 |     100 |     100 |                               
  index.ts                   |     100 |      100 |     100 |     100 |                               
  lat_lng.ts                 |     100 |      100 |     100 |     100 |                               
  lat_lng_bounds.ts          |     100 |      100 |     100 |     100 |                               
  mvc_object.ts              |     100 |      100 |   88.88 |     100 |                               
 src/directions              |     100 |    93.88 |     100 |     100 |                               
  defines.ts                 |     100 |      100 |     100 |     100 |                               
  directions_renderer.ts     |     100 |      100 |     100 |     100 |                               
  directions_service.ts      |     100 |      100 |     100 |     100 |                               
  distance_matrix_service.ts |     100 |      100 |     100 |     100 |                               
  helpers.ts                 |     100 |    84.28 |     100 |     100 | 40-41,64,78-109               
  index.ts                   |     100 |      100 |     100 |     100 |                               
 src/maps                    |   97.14 |    92.36 |    98.7 |   97.14 |                               
  index.ts                   |     100 |      100 |     100 |     100 |                               
  info_window.ts             |     100 |    95.65 |     100 |     100 | 118                           
  map.ts                     |     100 |      100 |     100 |     100 |                               
  map_type_control.ts        |     100 |      100 |     100 |     100 |                               
  marker.ts                  |   92.07 |    81.63 |      95 |   92.07 | 89-94,117-119,166,367,370,373 
 src/places                  |     100 |     97.5 |     100 |     100 |                               
  autocomplete.ts            |     100 |      100 |     100 |     100 |                               
  autocomplete_service.ts    |     100 |       85 |     100 |     100 | 160-162,262                   
  defines.ts                 |     100 |      100 |     100 |     100 |                               
  index.ts                   |     100 |      100 |     100 |     100 |                               
  opening_hours.ts           |     100 |      100 |     100 |     100 |                               
  place.ts                   |     100 |      100 |     100 |     100 |                               
  place_conversion.ts        |     100 |      100 |     100 |     100 |                               
  place_types.ts             |     100 |      100 |     100 |     100 |                               
  places_service.ts          |     100 |    97.91 |     100 |     100 | 245                           
  searchbox.ts               |     100 |    95.23 |     100 |     100 | 74                            
-----------------------------|---------|----------|---------|---------|-------------------------------

Test Suites: 12 passed, 12 total
Tests:       413 passed, 413 total
Snapshots:   0 total
Time:        6.751 s
Ran all test suites.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
