### PR TITLE
Add optimize waypoints example

### DIFF
--- a/examples/landingPage.html
+++ b/examples/landingPage.html
@@ -49,6 +49,11 @@
     </div>
 
     <div>
+      <span class="example-links"><a href="./optimizeWaypoints/index.html" target="_blank">Optimize Waypoints</a></span>
+      <span><a href="./optimizeWaypoints/google.html" target="_blank">(Google)</a></span>
+    </div>
+
+    <div>
       <span class="example-links"><a href="./markers/index.html" target="_blank">Markers</a></span>
       <span><a href="./markers/google.html" target="_blank">(Google)</a></span>
     </div>

--- a/examples/optimizeWaypoints/example.js
+++ b/examples/optimizeWaypoints/example.js
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This example demonstrates the waypoint optimization feature
+// using cities around Austin, TX.
+//
+// This is meant to showcase how the Amazon Location Migration SDK
+// handles waypoint optimization similar to Google Maps.
+
+function initMap() {
+  const austinCoords = { lat: 30.2672, lng: -97.7431 }; // Austin, TX
+
+  const directionsService = new google.maps.DirectionsService();
+  const directionsRenderer = new google.maps.DirectionsRenderer();
+
+  const map = new google.maps.Map(document.getElementById("map"), {
+    zoom: 8,
+    center: austinCoords,
+  });
+
+  directionsRenderer.setMap(map);
+
+  const onChangeHandler = function () {
+    calculateAndDisplayRoute(directionsService, directionsRenderer);
+  };
+
+  document.getElementById("start").addEventListener("change", onChangeHandler);
+  document.getElementById("waypoint1").addEventListener("change", onChangeHandler);
+  document.getElementById("waypoint2").addEventListener("change", onChangeHandler);
+  document.getElementById("waypoint3").addEventListener("change", onChangeHandler);
+  document.getElementById("end").addEventListener("change", onChangeHandler);
+  document.getElementById("optimize").addEventListener("change", onChangeHandler);
+}
+
+function calculateAndDisplayRoute(directionsService, directionsRenderer) {
+  // Create waypoint array to pass into route call
+  const waypoints = [];
+  for (let i = 1; i <= 3; i++) {
+    const elementValue = document.getElementById("waypoint" + i).value;
+    if (elementValue != "-") {
+      waypoints.push({
+        location: {
+          query: elementValue,
+        },
+        // All waypoints are stopovers by default
+        stopover: true,
+      });
+    }
+  }
+
+  // Check if optimization is enabled
+  const optimizeWaypoints = document.getElementById("optimize").checked;
+
+  // Make route call
+  directionsService
+    .route({
+      origin: {
+        query: document.getElementById("start").value,
+      },
+      destination: {
+        query: document.getElementById("end").value,
+      },
+      travelMode: google.maps.TravelMode.DRIVING,
+      waypoints: waypoints,
+      optimizeWaypoints: optimizeWaypoints,
+    })
+    .then((response) => {
+      // Display the optimized order in the UI
+      const waypointOrderDiv = document.getElementById("waypoint-order");
+      if (response.routes[0].waypoint_order && response.routes[0].waypoint_order.length > 0) {
+        const originalWaypoints = waypoints.map((wp) => wp.location.query);
+        const optimizedOrder = response.routes[0].waypoint_order.map((index) => {
+          // Extract just the city name without the state
+          const cityWithState = originalWaypoints[index];
+          const cityName = cityWithState.split(",")[0].trim();
+          // Capitalize the first letter of each word (/\b\w/g to match the first character (\w) of each word boundary (\b) in all word boundaries (g) in the cityName string)
+          return cityName.replace(/\b\w/g, (c) => c.toUpperCase());
+        });
+
+        waypointOrderDiv.innerHTML = "Optimized waypoint order: " + optimizedOrder.join(", ");
+      } else {
+        waypointOrderDiv.innerHTML = "No waypoint optimization performed";
+      }
+
+      directionsRenderer.setDirections(response);
+    })
+    .catch((e) => window.alert("Directions request failed due to " + e));
+}

--- a/examples/optimizeWaypoints/google.template.html
+++ b/examples/optimizeWaypoints/google.template.html
@@ -1,0 +1,166 @@
+<html>
+  <head>
+    <title>Optimize Waypoints Example - Google</title>
+    <link rel="stylesheet" type="text/css" href="../common/style.css" />
+
+    <!-- Client logic example -->
+    <script type="text/javascript" src="./example.js"></script>
+    <style>
+      #floating-panel {
+        width: 100%;
+        max-width: 100%;
+        padding: 5px;
+        box-sizing: border-box;
+      }
+      .dropdown-row {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 5px;
+        width: 100%;
+      }
+      .dropdown-item {
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+        margin-right: 10px;
+      }
+      .dropdown-item select {
+        margin-left: 5px;
+      }
+      .controls-container {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+        margin-top: 5px;
+        width: 100%;
+        gap: 20px;
+      }
+      .optimize-checkbox {
+        font-weight: bold;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+      #waypoint-order {
+        background-color: white;
+        padding: 5px 10px;
+        border-radius: 5px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+        flex-grow: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        display: inline-block;
+        max-width: 600px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="floating-panel">
+      <div class="dropdown-row">
+        <div class="dropdown-item">
+          <b>Start: </b>
+          <select id="start">
+            <option value="austin, tx">Austin</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>Waypoint 1: </b>
+          <select id="waypoint1">
+            <option value="-">-</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>Waypoint 2: </b>
+          <select id="waypoint2">
+            <option value="-">-</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>Waypoint 3: </b>
+          <select id="waypoint3">
+            <option value="-">-</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>End: </b>
+          <select id="end">
+            <option value="austin, tx">Austin</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+      </div>
+      <div class="controls-container">
+        <div class="optimize-checkbox">
+          <input type="checkbox" id="optimize" checked />
+          <label for="optimize">Optimize Waypoints</label>
+        </div>
+        <div id="waypoint-order">Select waypoints and calculate route</div>
+      </div>
+    </div>
+    <div id="map"></div>
+
+    <!-- Google Maps API import -->
+    <script
+      async
+      defer
+      src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_API_KEY}}&callback=initMap&libraries=places"
+    ></script>
+  </body>
+</html>

--- a/examples/optimizeWaypoints/index.template.html
+++ b/examples/optimizeWaypoints/index.template.html
@@ -1,0 +1,166 @@
+<html>
+  <head>
+    <title>Optimize Waypoints Example - Migration SDK</title>
+    <link rel="stylesheet" type="text/css" href="../common/style.css" />
+
+    <!-- Client logic example -->
+    <script type="text/javascript" src="./example.js"></script>
+    <style>
+      #floating-panel {
+        width: 100%;
+        max-width: 100%;
+        padding: 5px;
+        box-sizing: border-box;
+      }
+      .dropdown-row {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 5px;
+        width: 100%;
+      }
+      .dropdown-item {
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+        margin-right: 10px;
+      }
+      .dropdown-item select {
+        margin-left: 5px;
+      }
+      .controls-container {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: center;
+        margin-top: 5px;
+        width: 100%;
+        gap: 20px;
+      }
+      .optimize-checkbox {
+        font-weight: bold;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+      #waypoint-order {
+        background-color: white;
+        padding: 5px 10px;
+        border-radius: 5px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+        flex-grow: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        display: inline-block;
+        max-width: 600px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="floating-panel">
+      <div class="dropdown-row">
+        <div class="dropdown-item">
+          <b>Start: </b>
+          <select id="start">
+            <option value="austin, tx">Austin</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>Waypoint 1: </b>
+          <select id="waypoint1">
+            <option value="-">-</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>Waypoint 2: </b>
+          <select id="waypoint2">
+            <option value="-">-</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>Waypoint 3: </b>
+          <select id="waypoint3">
+            <option value="-">-</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+        <div class="dropdown-item">
+          <b>End: </b>
+          <select id="end">
+            <option value="austin, tx">Austin</option>
+            <option value="round rock, tx">Round Rock</option>
+            <option value="georgetown, tx">Georgetown</option>
+            <option value="san marcos, tx">San Marcos</option>
+            <option value="new braunfels, tx">New Braunfels</option>
+            <option value="bastrop, tx">Bastrop</option>
+            <option value="lockhart, tx">Lockhart</option>
+            <option value="buda, tx">Buda</option>
+            <option value="kyle, tx">Kyle</option>
+            <option value="pflugerville, tx">Pflugerville</option>
+            <option value="leander, tx">Leander</option>
+            <option value="cedar park, tx">Cedar Park</option>
+          </select>
+        </div>
+      </div>
+      <div class="controls-container">
+        <div class="optimize-checkbox">
+          <input type="checkbox" id="optimize" checked />
+          <label for="optimize">Optimize Waypoints</label>
+        </div>
+        <div id="waypoint-order">Select waypoints and calculate route</div>
+      </div>
+    </div>
+    <div id="map"></div>
+
+    <!-- Migration script import -->
+    <script
+      async
+      defer
+      src="../../dist/amazonLocationMigrationSDK.js?callback=initMap&region={{REGION}}&apiKey={{AMAZON_LOCATION_API_KEY}}"
+    ></script>
+  </body>
+</html>


### PR DESCRIPTION
### Description
- Add optimize waypoints example which takes strong influence from our directions example.
- The cities used in this example is limited to the cities around Austin due to Amazon Location's OptimizeWaypoints API's limitations described [here](https://github.com/aws-geospatial/amazon-location-migration/blob/main/documentation/directions.md).

### Testing
- Ran example. The section below describes the behavior.

---

#### Optimization Enabled

Amazon Location:

<img width="1000" height="860" alt="image" src="https://github.com/user-attachments/assets/3de441f6-474e-4bb3-996f-1c0e9605eab8" />

Google:

<img width="1000" height="860" alt="image" src="https://github.com/user-attachments/assets/4b948e4a-1cc0-41ae-8e65-318121e7bd6d" />

---

#### Optimization disabled

Amazon Location:

<img width="1000" height="860" alt="image" src="https://github.com/user-attachments/assets/881474ab-a74c-4326-90c3-937fc984f677" />

Google:

<img width="1000" height="860" alt="image" src="https://github.com/user-attachments/assets/51eeaeca-7903-49b7-a369-8e31cbb91708" />

