### PR TITLE
Add travel mode option to advanced example

### DIFF
--- a/examples/advanced/advanced.css
+++ b/examples/advanced/advanced.css
@@ -1,6 +1,6 @@
 .search-panel {
   height: 100%; /* Full height of the page */
-  width: 25%;
+  width: 384px;
   position: fixed;
   z-index: 1;
   top: 0;
@@ -217,4 +217,44 @@
 
 .hidden {
   display: none;
+}
+
+/* Travel Mode Styles */
+#travel-mode-container {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0;
+  padding: 10px 0;
+  border-bottom: 1px solid #e8eaed;
+}
+
+.travel-mode-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 15px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.travel-mode-option:hover {
+  background-color: #f1f3f4;
+}
+
+.travel-mode-option.active {
+  background-color: #e8f0fe;
+  color: #1a73e8;
+}
+
+.travel-mode-icon {
+  font-size: 24px;
+  margin-bottom: 4px;
+}
+
+.travel-mode-label {
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
 }

--- a/examples/advanced/example.js
+++ b/examples/advanced/example.js
@@ -27,6 +27,7 @@ let currentPlaces = [];
 let currentDisplayedPlace;
 let inDirectionsMode = false;
 let travelMode;
+let currentTravelMode;
 
 // navigator.geolocation.getCurrentPosition can sometimes take a long time to return,
 // so just cache the new position after receiving it and use it next time
@@ -96,6 +97,7 @@ async function initMap(center) {
   // Setup the directions service + renderer, and attach it to our map
   const { DirectionsRenderer, DirectionsService, TravelMode } = await google.maps.importLibrary("routes");
   travelMode = TravelMode;
+  currentTravelMode = travelMode.DRIVING; // Initialize currentTravelMode with DRIVING
   directionsService = new DirectionsService();
 
   // Setup our directions renderers
@@ -248,6 +250,7 @@ async function initMap(center) {
     // Switch to show the directions panel
     $("#places-container").hide();
     $("#directions-container").show();
+    $("#travel-mode-container").show(); // Show the travel mode container when directions are rendered
 
     inDirectionsMode = true;
 
@@ -265,6 +268,7 @@ async function initMap(center) {
   $("#close-directions").click(() => {
     // Switch back to the places panel
     $("#directions-container").hide();
+    $("#travel-mode-container").hide(); // Hide the travel mode container when directions are closed
     $("#places-container").show();
 
     // Clear the directions from the map
@@ -283,6 +287,28 @@ async function initMap(center) {
 
     $hoursExpanded.slideToggle(200);
     $toggleButton.html(isExpanded ? "▼" : "▲");
+  });
+
+  // Handle travel mode selection
+  $(".travel-mode-option").click(function () {
+    // Remove active class from all options
+    $(".travel-mode-option").removeClass("active");
+
+    // Add active class to the clicked option
+    $(this).addClass("active");
+
+    // Get the selected travel mode
+    const selectedMode = $(this).data("mode");
+
+    // Update the current travel mode
+    if (selectedMode === "DRIVING") {
+      currentTravelMode = travelMode.DRIVING;
+    } else if (selectedMode === "WALKING") {
+      currentTravelMode = travelMode.WALKING;
+    }
+
+    // Recalculate the route with the new travel mode
+    calculateRoute();
   });
 }
 
@@ -303,7 +329,7 @@ function calculateRoute() {
     .route({
       origin: originLocation,
       destination: destinationLocation,
-      travelMode: travelMode.DRIVING,
+      travelMode: currentTravelMode,
       provideRouteAlternatives: true,
     })
     .then((response) => {
@@ -477,6 +503,7 @@ async function createMarker(place) {
 
 // Hide the details by default and hide the directions container
 $("#directions-container").hide();
+$("#travel-mode-container").hide(); // Initially hide the travel mode container
 updatePlacesDetails();
 
 // Get our starting position -> initMap

--- a/examples/advanced/google.template.html
+++ b/examples/advanced/google.template.html
@@ -79,6 +79,18 @@
           <button id="close-directions">Close directions</button>
         </div>
 
+        <!-- Travel Mode Selection -->
+        <div id="travel-mode-container">
+          <div class="travel-mode-option active" data-mode="DRIVING">
+            <span class="travel-mode-icon">🚗</span>
+            <span class="travel-mode-label">Driving</span>
+          </div>
+          <div class="travel-mode-option" data-mode="WALKING">
+            <span class="travel-mode-icon">🚶</span>
+            <span class="travel-mode-label">Walking</span>
+          </div>
+        </div>
+
         <div id="origin-container">
           <input id="origin-input" class="input-field" type="text" placeholder="Enter origin, or click on map" />
         </div>

--- a/examples/advanced/index.template.html
+++ b/examples/advanced/index.template.html
@@ -79,6 +79,18 @@
           <button id="close-directions">Close directions</button>
         </div>
 
+        <!-- Travel Mode Selection -->
+        <div id="travel-mode-container">
+          <div class="travel-mode-option active" data-mode="DRIVING">
+            <span class="travel-mode-icon">🚗</span>
+            <span class="travel-mode-label">Driving</span>
+          </div>
+          <div class="travel-mode-option" data-mode="WALKING">
+            <span class="travel-mode-icon">🚶</span>
+            <span class="travel-mode-label">Walking</span>
+          </div>
+        </div>
+
         <div id="origin-container">
           <input id="origin-input" class="input-field" type="text" placeholder="Enter origin, or click on map" />
         </div>


### PR DESCRIPTION
### Description
- Add travel mode option to advanced example. We currently offer DRIVING and WALKING options.
- Gave side panel a hard-coded width so that the search box will fit nicely within the side panel no matter the dimensions of the screen.

### Testing
- Driving option selected:
<img width="1467" height="837" alt="image" src="https://github.com/user-attachments/assets/633c2bf1-bb05-43fd-9696-4471ffb092bb" />

- Walking option selected:
<img width="1467" height="837" alt="image" src="https://github.com/user-attachments/assets/4e715ade-27af-4e01-94cf-0cd302b12d18" />
