### PR TITLE
Pass in InstructionsMeasurementSystem property CalculateRoutes call

### DIFF
--- a/examples/advanced/advanced.css
+++ b/examples/advanced/advanced.css
@@ -249,6 +249,18 @@
   color: #1a73e8;
 }
 
+/* Ensure origin-input appears on top of destination-input dropdown */
+#origin-container {
+  position: relative;
+  z-index: 4; /* Higher z-index than destination container */
+}
+
+/* Ensure destination-input appears below origin-input dropdown */
+#destination-container {
+  position: relative;
+  z-index: 3; /* Higher z-index than search panel elements, but lower z-index than origin-container */
+}
+
 .travel-mode-icon {
   font-size: 24px;
   margin-bottom: 4px;

--- a/test/directions.test.ts
+++ b/test/directions.test.ts
@@ -2055,6 +2055,7 @@ import {
   CalculateRouteMatrixCommand,
   CalculateRoutesRequest,
   RouteTravelMode,
+  MeasurementSystem,
 } from "@aws-sdk/client-geo-routes";
 
 const directionsService = new MigrationDirectionsService();
@@ -3676,6 +3677,80 @@ test("should call route with options avoidFerries set to true and avoidTolls set
     expect(clientInput.Avoid?.TollRoads).toStrictEqual(true);
     expect(clientInput.Avoid?.TollTransponders).toStrictEqual(true);
 
+    done();
+  });
+});
+
+test("should call route with unitSystem set to IMPERIAL", (done) => {
+  // Mock the google object with UnitSystem so that we can use "google.maps.UnitSystem.IMPERIAL".
+  // We need to make it a partial type so that we are not required to mock out the other properties
+  // of the google.maps object.
+  (global.google as Partial<typeof google>) = {
+    maps: {
+      UnitSystem: {
+        IMPERIAL: 0,
+        METRIC: 1,
+      },
+    } as unknown as typeof google.maps,
+  };
+
+  const request = {
+    origin: {
+      placeId: "KEEP_AUSTIN_WEIRD",
+    },
+    destination: {
+      query: "another cool place",
+    },
+    travelMode: TravelMode.DRIVING,
+    unitSystem: google.maps.UnitSystem.IMPERIAL,
+  };
+
+  directionsService.route(request).then(() => {
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+    // Check that InstructionsMeasurementSystem is set to IMPERIAL
+    expect(clientInput.InstructionsMeasurementSystem).toEqual(MeasurementSystem.IMPERIAL);
+
+    // Clean up the mock
+    delete global.google;
+    done();
+  });
+});
+
+test("should call route with unitSystem set to METRIC", (done) => {
+  // Mock the google object with UnitSystem so that we can use "google.maps.UnitSystem.METRIC".
+  // We need to make it a partial type so that we are not required to mock out the other properties
+  // of the google.maps object.
+  (global.google as Partial<typeof google>) = {
+    maps: {
+      UnitSystem: {
+        IMPERIAL: 0,
+        METRIC: 1,
+      },
+    } as unknown as typeof google.maps,
+  };
+
+  const request = {
+    origin: {
+      placeId: "KEEP_AUSTIN_WEIRD",
+    },
+    destination: {
+      query: "another cool place",
+    },
+    travelMode: TravelMode.DRIVING,
+    unitSystem: google.maps.UnitSystem.METRIC,
+  };
+
+  directionsService.route(request).then(() => {
+    expect(mockedRoutesClientSend).toHaveBeenCalledWith(expect.any(CalculateRoutesCommand));
+    const clientInput: CalculateRoutesRequest = mockedRoutesClientSend.mock.calls[0][0].input;
+
+    // Check that InstructionsMeasurementSystem is set to METRIC
+    expect(clientInput.InstructionsMeasurementSystem).toEqual(MeasurementSystem.METRIC);
+
+    // Clean up the mock
+    delete global.google;
     done();
   });
 });


### PR DESCRIPTION
### Description
- Fix bug where `step.distance.text` is always in metric unit system even when imperial is specified or assumed (based on origin location).
  - We needed to pass in InstructionsMeasurementSystem property to the CalculateRoutes call.
- Fix bug where origin dropdown appeared under the destination dropdown in the advanced example.

### Testing
- `step.distance.text` is now the appropriate unit system based on the country the directions are in. For non US, Liberia, Myanmar countries, the text is metric as seen below by a route in Mexico.

<img width="1467" height="837" alt="image" src="https://github.com/user-attachments/assets/11fabfb3-151b-47ae-883a-bde83ae2a642" />

- And we can see for a route in the US, the text is imperial.

<img width="1467" height="837" alt="image" src="https://github.com/user-attachments/assets/3afed861-4ea0-4235-a7d8-80777f252d9a" />

- The origin dropdown now appears above the destination dropdown instead of behind it.

<img width="1467" height="837" alt="image" src="https://github.com/user-attachments/assets/c63cd5e5-14d2-4aaa-8ff8-bbcd596d0acb" />
