### PR TITLE
Added support for roundabout and uturn maneuvers

### DIFF
--- a/examples/advanced/example.js
+++ b/examples/advanced/example.js
@@ -331,18 +331,28 @@ function updateSelectedRouteIndex(index) {
 function getManeuverIcon(maneuver) {
   switch (maneuver) {
     case "turn-left":
+    case "turn-slight-left":
     case "turn-sharp-left":
-    case "ramp-left":
     case "fork-left":
       return "⬅️";
     case "turn-right":
+    case "turn-slight-right":
     case "turn-sharp-right":
-    case "ramp-right":
     case "fork-right":
       return "➡️";
     case "straight":
     case "continue":
       return "⬆️";
+    case "keep-left":
+      return "↙️";
+    case "keep-right":
+      return "↘️";
+    case "fork-left":
+    case "ramp-left":
+      return "↖️";
+    case "fork-right":
+    case "ramp-right":
+      return "↗️";
     case "uturn-left":
     case "uturn-right":
       return "↩️";

--- a/src/directions/helpers.ts
+++ b/src/directions/helpers.ts
@@ -406,9 +406,15 @@ export const getManeuver = (step: RouteVehicleTravelStep | RoutePedestrianTravel
       }
       break;
     }
+    case RouteVehicleTravelStepType.U_TURN: {
+      if ("UTurnStepDetails" in step) {
+        return `uturn-${step.UTurnStepDetails.SteeringDirection}`.toLowerCase();
+      }
+      break;
+    }
 
     // Both RouteVehicleTravelStep and RoutePedestrianTravelStep have
-    // TurnStepDetails and KeepStepDetails, so we can reference them for both
+    // TurnStepDetails, KeepStepDetails, and RoundaboutStepDetails
     case RouteVehicleTravelStepType.TURN:
     case RoutePedestrianTravelStepType.TURN: {
       return `turn-${step.TurnStepDetails.SteeringDirection}`.toLowerCase();
@@ -416,6 +422,16 @@ export const getManeuver = (step: RouteVehicleTravelStep | RoutePedestrianTravel
     case RouteVehicleTravelStepType.KEEP:
     case RoutePedestrianTravelStepType.KEEP: {
       return `keep-${step.KeepStepDetails.SteeringDirection}`.toLowerCase();
+    }
+    case RouteVehicleTravelStepType.ROUNDABOUT_ENTER:
+    case RouteVehicleTravelStepType.ROUNDABOUT_EXIT:
+    case RouteVehicleTravelStepType.ROUNDABOUT_PASS:
+    case RoutePedestrianTravelStepType.ROUNDABOUT_ENTER:
+    case RoutePedestrianTravelStepType.ROUNDABOUT_EXIT:
+    case RoutePedestrianTravelStepType.ROUNDABOUT_PASS: {
+      const stepDetails =
+        step.RoundaboutEnterStepDetails || step.RoundaboutExitStepDetails || step.RoundaboutPassStepDetails;
+      return `roundabout-${stepDetails.SteeringDirection}`.toLowerCase();
     }
   }
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -845,6 +845,32 @@ describe("getManeuver", () => {
     expect(getManeuver(step)).toStrictEqual("ramp-right");
   });
 
+  test("should return uturn-left maneuver for RouteVehicleTravelStep U_TURN type", () => {
+    const step: RouteVehicleTravelStep = {
+      UTurnStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RouteVehicleTravelStepType.U_TURN,
+      Duration: 0,
+    };
+
+    expect(getManeuver(step)).toStrictEqual("uturn-left");
+  });
+
+  test("should return uturn-right maneuver for RouteVehicleTravelStep U_TURN type", () => {
+    const step: RouteVehicleTravelStep = {
+      UTurnStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RouteVehicleTravelStepType.U_TURN,
+      Duration: 0,
+    };
+
+    expect(getManeuver(step)).toStrictEqual("uturn-right");
+  });
+
   test("should return turn-left maneuver for RouteVehicleTravelStep TURN type", () => {
     const step: RouteVehicleTravelStep = {
       TurnStepDetails: {
@@ -949,6 +975,146 @@ describe("getManeuver", () => {
     expect(getManeuver(step)).toStrictEqual("keep-right");
   });
 
+  test("should return roundabout-left maneuver for RouteVehicleTravelStep ROUNDABOUT types", () => {
+    const enterStep: RouteVehicleTravelStep = {
+      RoundaboutEnterStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RouteVehicleTravelStepType.ROUNDABOUT_ENTER,
+      Duration: 0,
+    };
+
+    expect(getManeuver(enterStep)).toStrictEqual("roundabout-left");
+
+    const exitStep: RouteVehicleTravelStep = {
+      RoundaboutExitStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RouteVehicleTravelStepType.ROUNDABOUT_EXIT,
+      Duration: 0,
+    };
+
+    expect(getManeuver(exitStep)).toStrictEqual("roundabout-left");
+
+    const passStep: RouteVehicleTravelStep = {
+      RoundaboutPassStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RouteVehicleTravelStepType.ROUNDABOUT_PASS,
+      Duration: 0,
+    };
+
+    expect(getManeuver(passStep)).toStrictEqual("roundabout-left");
+  });
+
+  test("should return roundabout-right maneuver for RouteVehicleTravelStep ROUNDABOUT types", () => {
+    const enterStep: RouteVehicleTravelStep = {
+      RoundaboutEnterStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RouteVehicleTravelStepType.ROUNDABOUT_ENTER,
+      Duration: 0,
+    };
+
+    expect(getManeuver(enterStep)).toStrictEqual("roundabout-right");
+
+    const exitStep: RouteVehicleTravelStep = {
+      RoundaboutExitStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RouteVehicleTravelStepType.ROUNDABOUT_EXIT,
+      Duration: 0,
+    };
+
+    expect(getManeuver(exitStep)).toStrictEqual("roundabout-right");
+
+    const passStep: RouteVehicleTravelStep = {
+      RoundaboutPassStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RouteVehicleTravelStepType.ROUNDABOUT_PASS,
+      Duration: 0,
+    };
+
+    expect(getManeuver(passStep)).toStrictEqual("roundabout-right");
+  });
+
+  test("should return roundabout-left maneuver for RoutePedestrianTravelStep ROUNDABOUT types", () => {
+    const enterStep: RoutePedestrianTravelStep = {
+      RoundaboutEnterStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RoutePedestrianTravelStepType.ROUNDABOUT_ENTER,
+      Duration: 0,
+    };
+
+    expect(getManeuver(enterStep)).toStrictEqual("roundabout-left");
+
+    const exitStep: RoutePedestrianTravelStep = {
+      RoundaboutExitStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RoutePedestrianTravelStepType.ROUNDABOUT_EXIT,
+      Duration: 0,
+    };
+
+    expect(getManeuver(exitStep)).toStrictEqual("roundabout-left");
+
+    const passStep: RoutePedestrianTravelStep = {
+      RoundaboutPassStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.LEFT,
+      },
+      Type: RoutePedestrianTravelStepType.ROUNDABOUT_PASS,
+      Duration: 0,
+    };
+
+    expect(getManeuver(passStep)).toStrictEqual("roundabout-left");
+  });
+
+  test("should return roundabout-right maneuver for RoutePedestrianTravelStep ROUNDABOUT types", () => {
+    const enterStep: RoutePedestrianTravelStep = {
+      RoundaboutEnterStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RoutePedestrianTravelStepType.ROUNDABOUT_ENTER,
+      Duration: 0,
+    };
+
+    expect(getManeuver(enterStep)).toStrictEqual("roundabout-right");
+
+    const exitStep: RoutePedestrianTravelStep = {
+      RoundaboutExitStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RoutePedestrianTravelStepType.ROUNDABOUT_EXIT,
+      Duration: 0,
+    };
+
+    expect(getManeuver(exitStep)).toStrictEqual("roundabout-right");
+
+    const passStep: RoutePedestrianTravelStep = {
+      RoundaboutPassStepDetails: {
+        Intersection: undefined,
+        SteeringDirection: RouteSteeringDirection.RIGHT,
+      },
+      Type: RoutePedestrianTravelStepType.ROUNDABOUT_PASS,
+      Duration: 0,
+    };
+
+    expect(getManeuver(passStep)).toStrictEqual("roundabout-right");
+  });
+
   test("should return empty string maneuver for unsupported type", () => {
     const step: RouteVehicleTravelStep = {
       ContinueStepDetails: {
@@ -973,6 +1139,15 @@ describe("getManeuver", () => {
   test("should return empty string maneuver for RoutePedestrianTravelStep EXIT type", () => {
     const step: RoutePedestrianTravelStep = {
       Type: RoutePedestrianTravelStepType.EXIT,
+      Duration: 0,
+    };
+
+    expect(getManeuver(step)).toStrictEqual("");
+  });
+
+  test("should return empty string maneuver for RoutePedestrianTravelStep U_TURN type", () => {
+    const step: RoutePedestrianTravelStep = {
+      Type: RoutePedestrianTravelStepType.U_TURN,
       Duration: 0,
     };
 


### PR DESCRIPTION
### Description
Added support for handling `uturn` and `roundabout` maneuvers. Also made some minor tweaks to the advanced example to have unique icons for keep and fork/ramp.

### Testing
Ran unit tests and verified retained 100% coverage. Also tested with various routes to exercise roundabouts and uturns and verified the expected maneuver is returned.