### PR TITLE
Remove callback to simplify advanced example

### DIFF
--- a/examples/advanced/example.js
+++ b/examples/advanced/example.js
@@ -424,9 +424,7 @@ async function initMap(center) {
     destinationLocation = currentDisplayedPlace.geometry.location;
     $("#destination-input").val(currentDisplayedPlace.formatted_address);
 
-    calculateRoute(() => {
-      $("#routes-container").show(); // Don't show container until route information is retrieved
-    });
+    calculateRoute();
   });
 
   $("#close-directions").click(() => {
@@ -644,7 +642,7 @@ function displayAlternateRoutes(directionsResult) {
   updateSelectedRouteIndex(0);
 }
 
-function calculateRoute(callback) {
+function calculateRoute() {
   directionsService
     .route({
       origin: originLocation,
@@ -687,10 +685,8 @@ function calculateRoute(callback) {
       // Display all alternate routes available in the display container
       displayAlternateRoutes(response);
 
-      // Execute the callback if provided
-      if (typeof callback === "function") {
-        callback();
-      }
+      // Show container once new route information is set
+      $("#routes-container").show();
     })
     .catch((error) => window.alert("Directions request failed due to " + error));
 }


### PR DESCRIPTION
### Description
- Simplify advanced example by removing callback in `calculateRoute` function and showing routes container at the end of every calculateRoute call.
- In instances where the route is already shown, the `show` call will be a no-op.

### Testing
- Verified functionality by running advanced example.