### PR TITLE
Added support for additional map styles

### DIFF
--- a/examples/vanilla/advanced/advanced.css
+++ b/examples/vanilla/advanced/advanced.css
@@ -392,24 +392,46 @@
   margin-bottom: 15px;
 }
 
-/* Layer toggles */
-#layer-toggles {
+/* Map controls (map type selector and layer toggles) */
+#map-controls {
   position: fixed;
   top: 10px;
   right: 50px;
   z-index: 1;
   display: flex;
-  gap: 8px;
+  gap: 4px;
+  background-color: white;
+  padding: 4px;
+  border-radius: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.map-control-select {
+  padding: 8px 12px;
+  background-color: transparent;
+  border: none;
+  border-radius: 16px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+  outline: none;
+}
+
+.map-control-select:hover {
+  background-color: #f1f3f4;
+}
+
+.map-control-select:focus {
+  background-color: #f1f3f4;
 }
 
 .layer-toggle {
   padding: 8px 12px;
-  background-color: white;
-  border: 1px solid #dadce0;
-  border-radius: 4px;
+  background-color: transparent;
+  border: none;
+  border-radius: 16px;
   cursor: pointer;
   font-size: 14px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   transition: background-color 0.2s;
 }
 
@@ -420,5 +442,36 @@
 .layer-toggle.active {
   background-color: #1a73e8;
   color: white;
-  border-color: #1a73e8;
+}
+
+/* Dark mode toggle */
+#dark-mode-toggle {
+  position: fixed;
+  top: 10px;
+  right: 400px;
+  z-index: 1;
+  display: flex;
+  gap: 4px;
+  background-color: white;
+  padding: 4px;
+  border-radius: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.mode-btn {
+  padding: 8px 12px;
+  background-color: transparent;
+  border: none;
+  border-radius: 16px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.mode-btn:hover {
+  background-color: #f1f3f4;
+}
+
+.mode-btn.active {
+  background-color: #1a73e8;
 }

--- a/examples/vanilla/advanced/example.js
+++ b/examples/vanilla/advanced/example.js
@@ -51,6 +51,86 @@ let lastUpdateZoom;
 let trafficLayer;
 let transitLayer;
 
+// Helper function to attach zoom-based route marker updates
+function attachZoomRouteMarkerListener() {
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom();
+
+    if (
+      currentTravelMode === travelMode.WALKING &&
+      mainDirectionRenderer.getDirections() &&
+      mainDirectionRenderer.getDirections().routes &&
+      mainDirectionRenderer.getDirections().routes.length > 0 &&
+      mainDirectionRenderer.getMap()
+    ) {
+      if (lastUpdateZoom === undefined) {
+        lastUpdateZoom = newZoom;
+      }
+
+      const cumulativeChange = Math.abs(newZoom - lastUpdateZoom);
+
+      if (cumulativeChange >= 0.1) {
+        updateRouteMarkers(mainDirectionRenderer.getDirections());
+        lastUpdateZoom = newZoom;
+      }
+    }
+  });
+}
+
+// Helper function to attach autocomplete bounds update listeners
+function attachAutocompleteBoundsListeners() {
+  map.addListener("zoom_changed", () => {
+    searchBarAutocomplete.setBounds(map.getBounds());
+    originAutocomplete.setBounds(map.getBounds());
+    destinationAutocomplete.setBounds(map.getBounds());
+  });
+
+  map.addListener("dragend", () => {
+    searchBarAutocomplete.setBounds(map.getBounds());
+    originAutocomplete.setBounds(map.getBounds());
+    destinationAutocomplete.setBounds(map.getBounds());
+  });
+}
+
+// Helper function to attach click listener for directions mode
+function attachDirectionsClickListener() {
+  map.addListener("click", (mapMouseEvent) => {
+    const clickedLatLng = mapMouseEvent.latLng;
+    const originInput = $("#origin-input").val();
+    const destinationInput = $("#destination-input").val();
+    let replacedInput = false;
+
+    if (!originInput) {
+      replacedInput = true;
+      originLocation = clickedLatLng;
+    } else if (!destinationInput) {
+      replacedInput = true;
+      destinationLocation = clickedLatLng;
+    }
+
+    if (replacedInput) {
+      calculateRoute();
+      geocoder
+        .geocode({
+          location: clickedLatLng,
+        })
+        .then((response) => {
+          const results = response.results;
+          if (results) {
+            const topResult = results[0];
+            const address = topResult.formatted_address;
+
+            if (!originInput) {
+              $("#origin-input").val(address);
+            } else if (!destinationInput) {
+              $("#destination-input").val(address);
+            }
+          }
+        });
+    }
+  });
+}
+
 // navigator.geolocation.getCurrentPosition can sometimes take a long time to return,
 // so just cache the new position after receiving it and use it next time
 async function getStartingPosition() {
@@ -198,47 +278,25 @@ function clearRouteMarkers() {
   }
 }
 
-async function initMap(center) {
+async function initMap(center, colorScheme = null) {
   // Store the user location so it can be used later by the directions
   userLocation = center;
 
   const { Map } = await google.maps.importLibrary("maps");
+
+  // Default to follow system preference if no color scheme provided
+  const mapColorScheme = colorScheme || "FOLLOW_SYSTEM";
+
   map = new Map(document.getElementById("map"), {
     center: center,
     zoom: 14,
     mapId: "DEMO_MAP_ID",
     mapTypeControl: false, // The map type control overlaps our panel, so don't show by default
+    colorScheme: mapColorScheme,
   });
 
-  // Add a listener for zoom changes to update markers when needed
-  map.addListener("zoom_changed", () => {
-    const newZoom = map.getZoom();
-
-    // If we have an active route with walking mode, update the markers
-    if (
-      currentTravelMode === travelMode.WALKING &&
-      mainDirectionRenderer.getDirections() &&
-      mainDirectionRenderer.getDirections().routes &&
-      mainDirectionRenderer.getDirections().routes.length > 0 &&
-      mainDirectionRenderer.getMap() // Ensure that the directions are being rendered
-    ) {
-      // Initialize the zoom tracking if it doesn't exist
-      if (lastUpdateZoom === undefined) {
-        lastUpdateZoom = newZoom;
-      }
-
-      // Calculate cumulative change since last marker update
-      const cumulativeChange = Math.abs(newZoom - lastUpdateZoom);
-
-      // Update markers if cumulative change exceeds threshold
-      if (cumulativeChange >= 0.1) {
-        updateRouteMarkers(mainDirectionRenderer.getDirections());
-
-        // Reset the lastUpdateZoom to current zoom after updating markers
-        lastUpdateZoom = newZoom;
-      }
-    }
-  });
+  // Attach zoom-based route marker updates
+  attachZoomRouteMarkerListener();
 
   const { Geocoder } = await google.maps.importLibrary("geocoding");
   geocoder = new Geocoder();
@@ -315,62 +373,12 @@ async function initMap(center) {
   });
 
   // Update our input field bounds whenever map bounds changes
-  map.addListener("zoom_changed", () => {
-    searchBarAutocomplete.setBounds(map.getBounds());
-
-    originAutocomplete.setBounds(map.getBounds());
-    destinationAutocomplete.setBounds(map.getBounds());
-  });
-  map.addListener("dragend", () => {
-    searchBarAutocomplete.setBounds(map.getBounds());
-
-    originAutocomplete.setBounds(map.getBounds());
-    destinationAutocomplete.setBounds(map.getBounds());
-  });
+  attachAutocompleteBoundsListeners();
 
   // If we are in directions mode, and the user has cleared out the origin
   // or destination input fields, clicking on the map should choose that
   // clicked location as the empty origin/destination
-  map.addListener("click", (mapMouseEvent) => {
-    const clickedLatLng = mapMouseEvent.latLng;
-
-    const originInput = $("#origin-input").val();
-    const destinationInput = $("#destination-input").val();
-    let replacedInput = false;
-
-    // Replace whichever input field is empty, starting with the origin (in case they are both empty)
-    if (!originInput) {
-      replacedInput = true;
-      originLocation = clickedLatLng;
-    } else if (!destinationInput) {
-      replacedInput = true;
-      destinationLocation = clickedLatLng;
-    }
-
-    // If one of the inputs was empty, calculate a new route and fill in the empty input field
-    if (replacedInput) {
-      calculateRoute();
-
-      // Use the geocoder to populate the input field we replaced with an address
-      geocoder
-        .geocode({
-          location: clickedLatLng,
-        })
-        .then((response) => {
-          const results = response.results;
-          if (results) {
-            const topResult = results[0];
-            const address = topResult.formatted_address;
-
-            if (!originInput) {
-              $("#origin-input").val(address);
-            } else if (!destinationInput) {
-              $("#destination-input").val(address);
-            }
-          }
-        });
-    }
-  });
+  attachDirectionsClickListener();
 
   // When user selects a single place or query list in SearchBox, show them in the
   // details pane and add marker(s) for the place(s).
@@ -489,12 +497,23 @@ async function initMap(center) {
   trafficLayer = new google.maps.TrafficLayer();
   transitLayer = new google.maps.TransitLayer();
 
-  // Handle terrain toggle
-  $("#terrain-toggle").click(function () {
-    $(this).toggleClass("active");
-
-    const isActive = $(this).hasClass("active");
-    map.setMapTypeId(isActive ? google.maps.MapTypeId.TERRAIN : google.maps.MapTypeId.ROADMAP);
+  // Handle map type selector
+  $("#map-type-selector").change(function () {
+    const selectedType = $(this).val();
+    switch (selectedType) {
+      case "roadmap":
+        map.setMapTypeId(google.maps.MapTypeId.ROADMAP);
+        break;
+      case "terrain":
+        map.setMapTypeId(google.maps.MapTypeId.TERRAIN);
+        break;
+      case "satellite":
+        map.setMapTypeId(google.maps.MapTypeId.SATELLITE);
+        break;
+      case "hybrid":
+        map.setMapTypeId(google.maps.MapTypeId.HYBRID);
+        break;
+    }
   });
 
   // Handle traffic layer toggle
@@ -512,6 +531,133 @@ async function initMap(center) {
     const isActive = $(this).hasClass("active");
     transitLayer.setMap(isActive ? map : null);
   });
+
+  // Dark mode functionality
+  let currentColorScheme = "FOLLOW_SYSTEM"; // Can be 'LIGHT', 'DARK', or 'FOLLOW_SYSTEM'
+
+  // Function to recreate the map with a new color scheme
+  async function recreateMapWithColorScheme(scheme) {
+    if (!map) return;
+
+    // Save current map state
+    const currentCenter = map.getCenter();
+    const currentZoom = map.getZoom();
+
+    // Save layer states and map type
+    const isTrafficActive = $("#traffic-toggle").hasClass("active");
+    const isTransitActive = $("#transit-toggle").hasClass("active");
+    const currentMapType = $("#map-type-selector").val();
+
+    // Clear existing markers and directions
+    markers.forEach((marker) => marker.setMap(null));
+    markers = [];
+
+    // Clear directions if they exist
+    if (mainDirectionRenderer) {
+      mainDirectionRenderer.setMap(null);
+    }
+    alternativeDirectionsRenderers.forEach((renderer) => {
+      renderer.setMap(null);
+    });
+    clearRouteMarkers();
+
+    // Recreate the map
+    const { Map } = await google.maps.importLibrary("maps");
+    map = new Map(document.getElementById("map"), {
+      center: currentCenter,
+      zoom: currentZoom,
+      mapId: "DEMO_MAP_ID",
+      mapTypeControl: false,
+      colorScheme: scheme,
+    });
+
+    // Restore map type based on saved value
+    switch (currentMapType) {
+      case "roadmap":
+        map.setMapTypeId(google.maps.MapTypeId.ROADMAP);
+        break;
+      case "terrain":
+        map.setMapTypeId(google.maps.MapTypeId.TERRAIN);
+        break;
+      case "satellite":
+        map.setMapTypeId(google.maps.MapTypeId.SATELLITE);
+        break;
+      case "hybrid":
+        map.setMapTypeId(google.maps.MapTypeId.HYBRID);
+        break;
+    }
+
+    // Restore map type selector dropdown value
+    $("#map-type-selector").val(currentMapType);
+
+    // Reattach all map listeners using shared helpers
+    attachZoomRouteMarkerListener();
+    attachAutocompleteBoundsListeners();
+    attachDirectionsClickListener();
+
+    // Reattach layers if they were active
+    if (isTrafficActive) {
+      trafficLayer.setMap(map);
+    }
+    if (isTransitActive) {
+      transitLayer.setMap(map);
+    }
+
+    // Reattach directions renderers
+    mainDirectionRenderer.setMap(map);
+    alternativeDirectionsRenderers.forEach((renderer) => {
+      renderer.setMap(map);
+    });
+
+    // Restore places if we have them
+    if (currentPlaces && currentPlaces.length > 0) {
+      currentPlaces.forEach((place) => {
+        createMarker(place);
+      });
+    }
+
+    // Recalculate route if in directions mode
+    if (inDirectionsMode && originLocation && destinationLocation) {
+      calculateRoute();
+    }
+  }
+
+  // Function to update the active button state
+  function updateActiveButton(buttonId) {
+    $(".mode-btn").removeClass("active");
+    $(`#${buttonId}`).addClass("active");
+  }
+
+  // Light mode button
+  $("#light-mode-btn").click(async function () {
+    currentColorScheme = "LIGHT";
+    await recreateMapWithColorScheme("LIGHT");
+    updateActiveButton("light-mode-btn");
+  });
+
+  // Dark mode button
+  $("#dark-mode-btn").click(async function () {
+    currentColorScheme = "DARK";
+    await recreateMapWithColorScheme("DARK");
+    updateActiveButton("dark-mode-btn");
+  });
+
+  // System mode button
+  $("#system-mode-btn").click(async function () {
+    currentColorScheme = "FOLLOW_SYSTEM";
+    await recreateMapWithColorScheme("FOLLOW_SYSTEM");
+    updateActiveButton("system-mode-btn");
+  });
+
+  // Listen for system color scheme changes when in FOLLOW_SYSTEM mode
+  if (window.matchMedia) {
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", async (e) => {
+      if (currentColorScheme === "FOLLOW_SYSTEM") {
+        // Recreate map with FOLLOW_SYSTEM to pick up the new system preference
+        await recreateMapWithColorScheme("FOLLOW_SYSTEM");
+      }
+    });
+  }
 }
 
 function highlightSelectedRoute(selectedIndex) {

--- a/examples/vanilla/advanced/google.template.html
+++ b/examples/vanilla/advanced/google.template.html
@@ -121,11 +121,23 @@
       <span>&#9776;</span>
     </div>
 
-    <!-- Map layer toggles -->
-    <div id="layer-toggles">
-      <button id="terrain-toggle" class="layer-toggle" title="Toggle Terrain">🗻 Terrain</button>
+    <!-- Map type and layer controls -->
+    <div id="map-controls">
+      <select id="map-type-selector" class="map-control-select" title="Map Type">
+        <option value="roadmap">🗺️ Roadmap</option>
+        <option value="terrain">🗻 Terrain</option>
+        <option value="satellite">🛰️ Satellite</option>
+        <option value="hybrid">🌍 Hybrid</option>
+      </select>
       <button id="traffic-toggle" class="layer-toggle" title="Toggle Traffic">🚦 Traffic</button>
       <button id="transit-toggle" class="layer-toggle" title="Toggle Transit">🚇 Transit</button>
+    </div>
+
+    <!-- Dark Mode Toggle -->
+    <div id="dark-mode-toggle">
+      <button id="light-mode-btn" class="mode-btn" title="Light Mode">☀️</button>
+      <button id="dark-mode-btn" class="mode-btn" title="Dark Mode">🌙</button>
+      <button id="system-mode-btn" class="mode-btn active" title="Follow System">💻</button>
     </div>
 
     <!-- Google Maps API import -->

--- a/examples/vanilla/advanced/index.template.html
+++ b/examples/vanilla/advanced/index.template.html
@@ -121,11 +121,23 @@
       <span>&#9776;</span>
     </div>
 
-    <!-- Map layer toggles -->
-    <div id="layer-toggles">
-      <button id="terrain-toggle" class="layer-toggle" title="Toggle Terrain">🗻 Terrain</button>
+    <!-- Map type and layer controls -->
+    <div id="map-controls">
+      <select id="map-type-selector" class="map-control-select" title="Map Type">
+        <option value="roadmap">🗺️ Roadmap</option>
+        <option value="terrain">🗻 Terrain</option>
+        <option value="satellite">🛰️ Satellite</option>
+        <option value="hybrid">🌍 Hybrid</option>
+      </select>
       <button id="traffic-toggle" class="layer-toggle" title="Toggle Traffic">🚦 Traffic</button>
       <button id="transit-toggle" class="layer-toggle" title="Toggle Transit">🚇 Transit</button>
+    </div>
+
+    <!-- Dark Mode Toggle -->
+    <div id="dark-mode-toggle">
+      <button id="light-mode-btn" class="mode-btn" title="Light Mode">☀️</button>
+      <button id="dark-mode-btn" class="mode-btn" title="Dark Mode">🌙</button>
+      <button id="system-mode-btn" class="mode-btn active" title="Follow System">💻</button>
     </div>
 
     <!-- Migration script import -->

--- a/src/maps/map.ts
+++ b/src/maps/map.ts
@@ -284,29 +284,33 @@ class MigrationMap {
       `https://maps.geo.${this._region}.amazonaws.com/v2/styles/${styleName}/descriptor?key=${this._apiKey}`,
     );
 
-    // Handle additional query params for Standard (ROADMAP and TERRAIN) types
-    // If we added these for other types, we would get a 4xx error
-    if (styleName == MapStyle.STANDARD) {
-      const params = new URLSearchParams(styleUrl.search);
+    // Handle additional query params based on map style
+    // If we added these for other unsupported types, we would get a 4xx error
+    const params = new URLSearchParams(styleUrl.search);
 
+    // Color scheme support: Standard, Hybrid, Satellite
+    if (styleName === MapStyle.STANDARD || styleName === MapStyle.HYBRID || styleName === MapStyle.SATELLITE) {
       params.set("color-scheme", this.#colorScheme);
-
-      // Add terrain query params for TERRAIN map type only
-      if (this.#mapTypeId === MapTypeId.TERRAIN) {
-        params.set("terrain", Terrain.HILLSHADE);
-        params.set("contour-density", ContourDensity.MEDIUM);
-      }
-
-      if (this.#traffic) {
-        params.set("traffic", this.#traffic);
-      }
-
-      if (this.#travelMode) {
-        params.set("travel-modes", this.#travelMode);
-      }
-
-      styleUrl.search = params.toString();
     }
+
+    // Terrain and contour density support: Standard (TERRAIN type only)
+    if (styleName === MapStyle.STANDARD && this.#mapTypeId === MapTypeId.TERRAIN) {
+      params.set("terrain", Terrain.HILLSHADE);
+      params.set("contour-density", ContourDensity.MEDIUM);
+    }
+
+    // Traffic support: Standard and Hybrid
+    if (this.#traffic && (styleName === MapStyle.STANDARD || styleName === MapStyle.HYBRID)) {
+      params.set("traffic", this.#traffic);
+    }
+
+    // Travel modes support: Standard and Hybrid
+    if (this.#travelMode && (styleName === MapStyle.STANDARD || styleName === MapStyle.HYBRID)) {
+      params.set("travel-modes", this.#travelMode);
+    }
+
+    // Always set the search params (will be a no-op if only the key param exists)
+    styleUrl.search = params.toString();
 
     this.#styleUrl = styleUrl.toString();
 

--- a/test/maps.test.ts
+++ b/test/maps.test.ts
@@ -277,20 +277,20 @@ test("should return correct mapTypeId after being modified", () => {
   expect(testMap.getMapTypeId()).toStrictEqual(MapTypeId.ROADMAP);
   expect(mockSetStyle).toHaveBeenCalledTimes(0);
 
-  // Can set/get to HYBRID and style URL is updated
+  // Can set/get to HYBRID and style URL is updated with color-scheme
   testMap.setMapTypeId(MapTypeId.HYBRID);
   expect(testMap.getMapTypeId()).toStrictEqual(MapTypeId.HYBRID);
   expect(mockSetStyle).toHaveBeenCalledTimes(1);
   expect(mockSetStyle).toHaveBeenLastCalledWith(
-    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key",
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key&color-scheme=Light",
   );
 
-  // Can set/get to SATELLITE and style URL is updated
+  // Can set/get to SATELLITE and style URL is updated with color-scheme
   testMap.setMapTypeId(MapTypeId.SATELLITE);
   expect(testMap.getMapTypeId()).toStrictEqual(MapTypeId.SATELLITE);
   expect(mockSetStyle).toHaveBeenCalledTimes(2);
   expect(mockSetStyle).toHaveBeenLastCalledWith(
-    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key",
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key&color-scheme=Light",
   );
 
   // Can set/get to TERRAIN and style URL is updated
@@ -311,6 +311,30 @@ test("should allow Dark color scheme when mapTypeId is TERRAIN", () => {
   expect(mockSetStyle).toHaveBeenCalledTimes(1);
   expect(mockSetStyle).toHaveBeenLastCalledWith(
     "https://maps.geo.test-region.amazonaws.com/v2/styles/Standard/descriptor?key=test-api-key&color-scheme=Dark&terrain=Hillshade&contour-density=Medium",
+  );
+});
+
+test("should allow Dark color scheme when mapTypeId is HYBRID", () => {
+  const testMap = new MigrationMap(null, {
+    colorScheme: ColorScheme.DARK,
+  });
+
+  testMap.setMapTypeId(MapTypeId.HYBRID);
+  expect(mockSetStyle).toHaveBeenCalledTimes(1);
+  expect(mockSetStyle).toHaveBeenLastCalledWith(
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key&color-scheme=Dark",
+  );
+});
+
+test("should allow Dark color scheme when mapTypeId is SATELLITE", () => {
+  const testMap = new MigrationMap(null, {
+    colorScheme: ColorScheme.DARK,
+  });
+
+  testMap.setMapTypeId(MapTypeId.SATELLITE);
+  expect(mockSetStyle).toHaveBeenCalledTimes(1);
+  expect(mockSetStyle).toHaveBeenLastCalledWith(
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key&color-scheme=Dark",
   );
 });
 
@@ -376,6 +400,64 @@ test("should remove transit param when TransitLayer is removed from map", () => 
   );
 });
 
+test("should set traffic param when TrafficLayer is added to HYBRID map", () => {
+  const testMap = new MigrationMap(null, {
+    mapTypeId: MapTypeId.HYBRID,
+  });
+  const trafficLayer = new MigrationTrafficLayer();
+
+  trafficLayer.setMap(testMap);
+
+  expect(mockSetStyle).toHaveBeenCalledTimes(1);
+  expect(mockSetStyle).toHaveBeenLastCalledWith(
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key&color-scheme=Light&traffic=All",
+  );
+});
+
+test("should set transit param when TransitLayer is added to HYBRID map", () => {
+  const testMap = new MigrationMap(null, {
+    mapTypeId: MapTypeId.HYBRID,
+  });
+  const transitLayer = new MigrationTransitLayer();
+
+  transitLayer.setMap(testMap);
+
+  expect(mockSetStyle).toHaveBeenCalledTimes(1);
+  expect(mockSetStyle).toHaveBeenLastCalledWith(
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key&color-scheme=Light&travel-modes=Transit",
+  );
+});
+
+test("should not set traffic param when TrafficLayer is added to SATELLITE map", () => {
+  const testMap = new MigrationMap(null, {
+    mapTypeId: MapTypeId.SATELLITE,
+  });
+  const trafficLayer = new MigrationTrafficLayer();
+
+  trafficLayer.setMap(testMap);
+
+  // Traffic is not supported on SATELLITE, so the URL should not include traffic param
+  expect(mockSetStyle).toHaveBeenCalledTimes(1);
+  expect(mockSetStyle).toHaveBeenLastCalledWith(
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key&color-scheme=Light",
+  );
+});
+
+test("should not set transit param when TransitLayer is added to SATELLITE map", () => {
+  const testMap = new MigrationMap(null, {
+    mapTypeId: MapTypeId.SATELLITE,
+  });
+  const transitLayer = new MigrationTransitLayer();
+
+  transitLayer.setMap(testMap);
+
+  // Transit is not supported on SATELLITE, so the URL should not include travel-modes param
+  expect(mockSetStyle).toHaveBeenCalledTimes(1);
+  expect(mockSetStyle).toHaveBeenLastCalledWith(
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key&color-scheme=Light",
+  );
+});
+
 test("should update mapTypeId through new options", () => {
   const testMap = new MigrationMap(null, {});
 
@@ -387,11 +469,11 @@ test("should update mapTypeId through new options", () => {
     mapTypeId: MapTypeId.HYBRID,
   });
 
-  // mapTypeId should be updated from the setOptions call and new style URL set
+  // mapTypeId should be updated from the setOptions call and new style URL set with color-scheme
   expect(testMap.getMapTypeId()).toStrictEqual(MapTypeId.HYBRID);
   expect(mockSetStyle).toHaveBeenCalledTimes(1);
   expect(mockSetStyle).toHaveBeenLastCalledWith(
-    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key",
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Hybrid/descriptor?key=test-api-key&color-scheme=Light",
   );
 });
 
@@ -665,12 +747,12 @@ test("MapTypeControl should change mapTypeId when button is clicked", () => {
   // Before clicking the buttons, the mockSetStyle shouldn't be called yet
   expect(mockSetStyle).toHaveBeenCalledTimes(0);
 
-  // Clicking the Satellite button should set the Satellite style
+  // Clicking the Satellite button should set the Satellite style with color-scheme
   buttons[0].click();
   expect(mockSetStyle).toHaveBeenCalledTimes(1);
   const firstNewStyle = mockSetStyle.mock.calls[0][0];
   expect(firstNewStyle).toStrictEqual(
-    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key",
+    "https://maps.geo.test-region.amazonaws.com/v2/styles/Satellite/descriptor?key=test-api-key&color-scheme=Light",
   );
 
   // Clicking the Map button should set the Standard style


### PR DESCRIPTION
### Description
Extended support for additional map style combinations from latest maps release:
1. Color Scheme (Dark) for Hybrid/Satellite
1. Traffic for Hybrid
1. Travel Modes (Transit & Truck) forHybrid

### Testing
Updated advanced example to better show-case switching between the different map styles and toggling on the traffic/transit layers. Visually verified we still get no 4xx errors when trying all the different combinations, and at the newly supported style combinations now work. Also updated unit tests to retain our 100% coverage of the maps class.

https://github.com/user-attachments/assets/1495123e-248e-4e64-89ca-9a798ca27eae
