### PR TITLE
Release new version with transit routing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.4.0
+
+### ✨ Features and improvements
+
+- **Transit Routing**: Added support for `TravelMode.TRANSIT` in `DirectionsRequest`, leveraging Amazon Location's [new public transit routing](https://aws.amazon.com/about-aws/whats-new/2026/06/amazon-location-service/amazon-location-new-public-transit-intermodal-routing/). Includes `transitOptions.modes` mapping, rich `transit_details` on each step, and an updated advanced demo showcasing transit routes
+- Updated `@aws-sdk/client-geo-routes`, `@aws-sdk/client-geo-places`, and `@aws-sdk/client-geo-maps` to `^3.1063.0`
+
 # 1.3.1
 
 ### ✨ Features and improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-migration-sdk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-migration-sdk",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-geo-maps": "^3.1063.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/amazon-location-migration-sdk",
   "description": "Amazon Location Migration SDK for JavaScript",
   "license": "Apache-2.0",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
### Description
Bump minor version to `1.4.0` to release support for transit routing.